### PR TITLE
Remove hard-coded paths in parse_metadata.py

### DIFF
--- a/genweb/README.md
+++ b/genweb/README.md
@@ -1,0 +1,22 @@
+# documentation
+
+## parse_metadata.yml
+
+`parse_metdata.py` references paths for you machine in `parse_metadata.yml`. 
+Here are the example values on my machine:
+
+- `xmldir`: /Users/marcp/Desktop/metadata/xml
+- `srcdir`: /Users/marcp/Desktop/metadata
+- `finalyaml`: /Users/marcp/Desktop/metadata.yml
+
+When you run `parse_metadata.py` for the first time it will print the path for `parse_metadata.yml`.
+
+## file layout of website
+
+- each person has a folder named after their ID
+- {id}/index.html is the main display for that person
+- {id}/{id}.jpg is the designated thumbnail for that person
+- Images are {id}/YYYYMMDDNN{id}.jpg where NN is an index that starts at 00
+- Images named {id}/+YYYYMMDDNN{id}.jpg is a full resoltion image
+- Images without the leading + are the thumbnails
+- type=href has a sub-dir (`folder`)

--- a/genweb/parse_metadata.py
+++ b/genweb/parse_metadata.py
@@ -5,7 +5,11 @@
 from xml.etree.ElementTree import parse, ParseError
 from os import walk
 from os.path import join, splitext
+from platform import system
+from sys import exit as return_code
+
 from yaml import dump
+from devopsdriver.settings import Settings
 
 
 def read_xml(path: str) -> dict:
@@ -35,8 +39,20 @@ def read_xml(path: str) -> dict:
 def main() -> None:
     """searches for xml files and merges into yml file"""
     metadata = {}
+    settings = Settings(__file__)
 
-    for root, _, files in walk("/home/pagerk/metadata/xml"):
+    if "xmldir" not in settings:
+        print("ERROR: Please make sure you add xmldir, srcdir, and finalyaml to:")
+        print(
+            "\t"
+            + Settings.PREF_DIR.get(
+                system(), Settings.PREF_DIR[Settings.DEFAULT_PREF_DIR]
+            )
+            + "/parse_metadata.yml"
+        )
+        return_code(1)
+
+    for root, _, files in walk(settings["xmldir"]):
         for file in [f for f in files if splitext(f)[1].lower() == ".xml"]:
             try:
                 metadata[splitext(file)[0]] = read_xml(join(root, file))
@@ -44,7 +60,12 @@ def main() -> None:
             except (ParseError, IndexError, AssertionError) as error:
                 print(join(root, file))
                 print(error)
-    with open("metadata.yml", "w", encoding="utf-8") as file:
+
+    for entry in metadata.values():
+        if entry["type"] == "inline":
+            pass
+
+    with open(settings["finalyaml"], "w", encoding="utf-8") as file:
         dump(metadata, file)
 
 

--- a/genweb/people.py
+++ b/genweb/people.py
@@ -98,9 +98,6 @@ class People:
     def __len__(self) -> int:
         return len(self.by_id)
 
-    def __delitem__(self, key: str):
-        del self.by_id[key]
-
     def has_key(self, key: str) -> bool:
         """Is the given identifier available
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,9 @@ dynamic = ["version"]
 requires-python = ">= 3.9"
 dependencies = [
   "PyYAML==6.0.1",
-  "Mako==1.3.5",
+  "Mako==1.3.3",
   "python-gedcom==1.0.0",
+  "devopsdriver==0.1.45",
 ]
 keywords = ["geneology", "familyhistory", "photos"]
 classifiers=[

--- a/tests/test_people.py
+++ b/tests/test_people.py
@@ -10,6 +10,28 @@ from datetime import date
 from genweb.people import People
 
 
+def test_dict_operators() -> None:
+    gedcom_list = [
+        SimpleNamespace(
+            id="1",
+            given="John Smith",
+            surname="Doe",
+            gender="M",
+            birthdate=date(1973, 6, 30),
+            parents=set(),
+            spouses=set(),
+            children=set(),
+        ),
+    ]
+
+    gedcom = {p.id: p for p in gedcom_list}
+    assert len(gedcom) == len(gedcom_list)
+    people = People(gedcom)
+    assert "DoeJohnS1973-" in repr(people), repr(people)
+    assert people.has_key("DoeJohnS1973-"), people
+    assert "DoeJohnS1973-" in people.keys(), people
+
+
 def test_middle_initial() -> None:
     gedcom_list = [
         SimpleNamespace(
@@ -23,14 +45,15 @@ def test_middle_initial() -> None:
             children=set(),
         ),
     ]
-    
+
     gedcom = {p.id: p for p in gedcom_list}
     assert len(gedcom) == len(gedcom_list)
     people = People(gedcom)
     assert len(people) == 1, people
     assert "DoeJohnS1973-" in people, people
     assert people["DoeJohnS1973-"].given == "John Smith", people["DoeJohnS1973-"].given
-    
+
+
 def test_basic() -> None:
     gedcom_list = [
         SimpleNamespace(
@@ -84,10 +107,15 @@ def test_basic() -> None:
     assert "DoeJames2004SmithSally1971" in people, people
     assert people["DoeJohn1973-"].given == "John", people["DoeJohn1973-"]
     assert people["SmithSally1971-"].given == "Sally", people["SmithSally1971-"]
-    assert people["DoeJames2004SmithSally1971"].given == "James", people["DoeJames2004SmithSally1971"]
-    assert people["DoeJane2007SmithSally1971"].given == "Jane", people["DoeJane2007SmithSally1971"]
+    assert people["DoeJames2004SmithSally1971"].given == "James", people[
+        "DoeJames2004SmithSally1971"
+    ]
+    assert people["DoeJane2007SmithSally1971"].given == "Jane", people[
+        "DoeJane2007SmithSally1971"
+    ]
 
 
 if __name__ == "__main__":
+    test_dict_operators()
     test_basic()
     test_middle_initial()

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -11,6 +11,14 @@ from genweb.relationships import load_gedcom, parse_date
 DATA_DIR = join(dirname(__file__), "data")
 
 
+def test_bad_date_parse() -> None:
+    try:
+        _ = parse_date("garbage date")
+        raise AssertionError("We should have failed")
+    except ValueError:
+        pass
+
+
 def test_date_parse() -> None:
     dates = {
         "CHILD": date(1, 1, 1),
@@ -92,6 +100,7 @@ def test_general() -> None:
 
 
 if __name__ == "__main__":
+    test_bad_date_parse()
     test_date_parse()
     test_empty()
     test_marriage()


### PR DESCRIPTION
When you run `parse_metadata.py` for the first time after this change it will print the path to a file. Add the following to that yaml file (of course update the paths to paths on your machine):

```Yaml
xmldir: /Users/marcp/Desktop/metadata/xml
srcdir: /Users/marcp/Desktop/metadata
finalyaml: /Users/marcp/Desktop/metadata.yml
```

Also added some more test coverage to bring test coverage back up to 75%