### PR TITLE
We now include .src files in the output

### DIFF
--- a/genweb/data/styles.css
+++ b/genweb/data/styles.css
@@ -24,13 +24,35 @@
     vertical-align: middle;
     transform-origin:left;
     transform: rotate(-90deg) translate(-100%,10px);
-    float: left;                
+    float: left;
 }
 
 .controls{
     position:fixed;
-    top:0;
-    right:0;
+    top:15px;
+    right:30px;
+    font-size: xxx-large;
+}
+
+.inline_element {
+    margin:15px;
+    padding:15px;
+    border-radius: 15px;
+    background-color: antiquewhite;
+}
+
+.header {
+    height:96px;
+}
+
+.thumb {
+    position:fixed;
+    top:15px;
+    left:30px;
+}
+
+.thumb_image {
+    border-radius: 50%;
 }
 
 h1 {

--- a/genweb/templates/person.html.mako
+++ b/genweb/templates/person.html.mako
@@ -12,11 +12,14 @@ displayed_metadata=[metadata[i] for i in person.metadata]
         <link rel="stylesheet" href="../static/styles.css">
     </head>
 	<body class="notranslate">
-        <h1>
-            <a name="Top"></a>${person.surname}, ${person.given}
-             - ${'?' if person.birthdate is None else person.birthdate.strftime("%Y")}
-             - ${'?' if person.deathdate is None else person.deathdate.strftime("%Y")}
-        </h1>
+        <div class="header">
+            <div class="thumb"><img src="${person.id}.jpg" height=64 class="thumb_image"/></div>
+            <h1>
+                <a name="Top"></a>${person.surname}, ${person.given}
+                - ${'?' if person.birthdate is None else person.birthdate.strftime("%Y")}
+                - ${'?' if person.deathdate is None else person.deathdate.strftime("%Y")}
+            </h1>
+        </div>
         <div class="controls">
             <a href="../index.html">&#x1f3e0;</a>
         </div>
@@ -59,9 +62,14 @@ displayed_metadata=[metadata[i] for i in person.metadata]
                 </table>
                 
                 <div class="ReturnToTop"><a href="#Top"><span style="font-size:xxx-large">&#x1F51D;</span></a></div>
-
-              
-                    </div>
+            </div>
+            % elif element["type"] == "inline":
+            <div class="inline_element">
+                <a name="${element["file"]}"/>
+		        <H2  style="text-align:center;margin-left:auto;margin-right:auto;">${element.get("title", "Untitled")}</H2>
+        <p><a href="mailto:pagerk@gmail.com?subject=${element["file"]}" target="_blank"><span style="font-size:xxx-large">&#x1f4e7;</span></a></p>
+                ${element.get("contents", "<b>content missing</b>")}
+            </div>
             % endif
             % endfor
         </div>

--- a/tests/test_genweb.py
+++ b/tests/test_genweb.py
@@ -41,7 +41,7 @@ def test_generate_people_pages() -> None:
         "4": SimpleNamespace(parents=[], gender="F", surname="Jones", metadata=[]),
         "5": SimpleNamespace(parents=[], gender="F", surname="Brown", metadata=[]),
     }
-    metadata = {"1": {"type": "inline"}, "2": {"type": "inline"}}
+    metadata = {"1": {"type": "dummy"}, "2": {"type": "dummy"}}
     with TemporaryDirectory() as working_dir:
         generate_people_pages(working_dir, people, metadata)
 


### PR DESCRIPTION
- inline .src files are now built-on in the `metadata.yml`
- inline is now emitted in the output <img width="1440" alt="Screenshot 2024-08-08 at 2 41 33 PM" src="https://github.com/user-attachments/assets/7b224ab5-c56d-4578-8bba-ae46fd78523d">
- Added thumbnail for the person the page is for and made the home icon bigger <img width="1440" alt="Screenshot 2024-08-08 at 2 40 26 PM" src="https://github.com/user-attachments/assets/6f0c3282-4d1f-4280-929f-af2bc8abc6df">
