### PR TITLE
Grouping items by year in person view

### DIFF
--- a/genweb/templates/inline.html.mako
+++ b/genweb/templates/inline.html.mako
@@ -1,0 +1,8 @@
+<%page 
+    args="element"
+/><div class="inline_element">
+    <a name="${element["file"]}"/>
+    <H2  style="text-align:center;margin-left:auto;margin-right:auto;">${element.get("title", "Untitled")}</H2>
+<p><a href="mailto:pagerk@gmail.com?subject=${element["file"]}" target="_blank"><span style="font-size:xxx-large">&#x1f4e7;</span></a></p>
+    ${element.get("contents", "<b>content missing</b>")}
+</div>

--- a/genweb/templates/nav_area.html.mako
+++ b/genweb/templates/nav_area.html.mako
@@ -10,7 +10,7 @@ display_people = [p for p in people_ids if p in people and people[p].metadata]
     % for person in display_people:
         <div class="person">
            <a href="../${person}/index.html"> 
-                <img src = "../${person}/${person}.jpg" height=64/>
+                <img src = "../${person}/${person}.jpg" height=64 class="thumb_image"/>
                 <br/>
                 ${people[person].given.split(" ")[0]}
             </a>

--- a/genweb/templates/person.html.mako
+++ b/genweb/templates/person.html.mako
@@ -3,13 +3,19 @@
 />
 <%
 displayed_metadata=[metadata[i] for i in person.metadata]
+displayed_metadata.sort(key=lambda e:e.get("file", ""))
+years = sorted(set(e.get('file', "0000")[:4] for e in displayed_metadata))
 %><!DOCTYPE html>
 <html lang="en" translate="no" class="notranslate">
 	<head>
+        <title>${person.surname}, ${person.given}</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta charset="utf-8"/>
 		<meta name="google" content="notraslate"/>
         <link rel="stylesheet" href="../static/styles.css">
+        <script>
+            <%include file="actions.js"/>
+        </script>
     </head>
 	<body class="notranslate">
         <div class="header">
@@ -25,52 +31,29 @@ displayed_metadata=[metadata[i] for i in person.metadata]
         </div>
 
         <div class="nav_area">
-            <%include file="nav_area.html.mako" args="people_ids = person.parents,people=people,area_class='parent_area',label='PARENTS'"/>
-            <%include file="nav_area.html.mako" args="people_ids = person.spouses,people=people,area_class='spouse_area',label='SPOUSES'"/>
-            <%include file="nav_area.html.mako" args="people_ids = person.children,people=people,area_class='child_area',label='CHILDREN'"/>
+            <%
+            from datetime import date
+            children = [i for i in person.children if i in people and people[i].metadata]
+            children.sort(key=lambda i:people[i].birthdate if people[i].birthdate else date.today(), reverse=False)
+            %>
+            <%include file="nav_area.html.mako" args="people_ids=person.parents,people=people,area_class='parent_area',label='PARENTS'"/>
+            <%include file="nav_area.html.mako" args="people_ids=person.spouses,people=people,area_class='spouse_area',label='SPOUSES'"/>
+            <%include file="nav_area.html.mako" args="people_ids=children,people=people,area_class='child_area',label='CHILDREN'"/>
 
         </div>
         <div class="image_area">
-            % for element in displayed_metadata:
-            % if element["type"] == "picture":
-            <div class="picture_element">
-
-                <a name="${element["file"]}"/>
-                <table WIDTH="600" Align="CENTER" NOBORDER COLS="2">
-                    <tr>
-                        <td ALIGN="CENTER" VALIGN="TOP">
-                        <table Align=CENTER BORDER CELLPADDING="4" CELLSPACING="4" COLS="1">
-                            <tr>
-                                <td ALIGN="CENTER" VALIGN="TOP">
-                                    <H2>${element.get("title","")}</H2>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td ALIGN="CENTER" VALIGN="TOP">
-                                    <img src="../${element["path"]}/${element["file"]}" target="Resource Window">
-                                </td>
-                            </tr>
-                            <tr>
-                                <td ALIGN="CENTER" VALIGN="TOP">
-                                    <p>${element.get("caption","")}</p>
-        <p><a href="mailto:pagerk@gmail.com?subject=${element["file"]}" target="_blank"><span style="font-size:xxx-large">&#x1f4e7;</span></a></p>
-                                </td>
-                            </tr>
-                            </table>
-                        </td>
-                    </tr>
-                </table>
-                
-                <div class="ReturnToTop"><a href="#Top"><span style="font-size:xxx-large">&#x1F51D;</span></a></div>
-            </div>
-            % elif element["type"] == "inline":
-            <div class="inline_element">
-                <a name="${element["file"]}"/>
-		        <H2  style="text-align:center;margin-left:auto;margin-right:auto;">${element.get("title", "Untitled")}</H2>
-        <p><a href="mailto:pagerk@gmail.com?subject=${element["file"]}" target="_blank"><span style="font-size:xxx-large">&#x1f4e7;</span></a></p>
-                ${element.get("contents", "<b>content missing</b>")}
-            </div>
-            % endif
+            % for year in years:
+                <span id="year-${year}-button" onclick="show_hide('year-${year}')" style="font-size:xx-large">▸</span>
+                <span style="font-size:xxx-large" onclick="show_hide('year-${year}')">${year}</span>
+                <div id="year-${year}" style="display:none">
+                % for element in [e for e in displayed_metadata if e.get("file", "0000").startswith(year)]:
+                % if element["type"] == "picture":
+                    <%include file="picture.html.mako" args="element=element"/>
+                % elif element["type"] == "inline":
+                    <%include file="inline.html.mako" args="element=element"/>
+                % endif
+                % endfor
+                </div>
             % endfor
         </div>
 

--- a/genweb/templates/picture.html.mako
+++ b/genweb/templates/picture.html.mako
@@ -1,0 +1,31 @@
+<%page 
+    args="element"
+/><div class="picture_element">
+    <a name="${element["file"]}"/>
+    <table WIDTH="600" Align="CENTER" NOBORDER COLS="2">
+        <tr>
+            <td ALIGN="CENTER" VALIGN="TOP">
+            <table Align=CENTER BORDER CELLPADDING="4" CELLSPACING="4" COLS="1">
+                <tr>
+                    <td ALIGN="CENTER" VALIGN="TOP">
+                        <H2>${element.get("title","")}</H2>
+                    </td>
+                </tr>
+                <tr>
+                    <td ALIGN="CENTER" VALIGN="TOP">
+                        <img src="../${element["path"]}/${element["file"]}" target="Resource Window">
+                    </td>
+                </tr>
+                <tr>
+                    <td ALIGN="CENTER" VALIGN="TOP">
+                        <p>${element.get("caption","")}</p>
+<p><a href="mailto:pagerk@gmail.com?subject=${element["file"]}" target="_blank"><span style="font-size:xxx-large">&#x1f4e7;</span></a></p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+    
+    <div class="ReturnToTop"><a href="#Top"><span style="font-size:xxx-large">&#x1F51D;</span></a></div>
+</div>

--- a/genweb/templates/top_level.html.mako
+++ b/genweb/templates/top_level.html.mako
@@ -7,6 +7,7 @@ people_list = sorted(people.values(),key=lambda p:f'{p.surname}, {p.given}')
 %><!DOCTYPE html>
 <html lang="en" translate="no" class="notranslate">
 	<head>
+        <title>Family</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta charset="utf-8"/>
 		<meta name="google" content="notraslate"/>
@@ -16,13 +17,14 @@ people_list = sorted(people.values(),key=lambda p:f'{p.surname}, {p.given}')
         </script>
     </head>
 	<body class="notranslate">
+        <center><h1>Family</h1></center>
         % for letter in letters:
         <span id="letter-${letter}-button" onclick="show_hide('letter-${letter}')" style="font-size:xx-large">▸</span>
-        <span style="font-size:xxx-large">${letter}</span>
+        <span style="font-size:xxx-large" onclick="show_hide('letter-${letter}')">${letter}</span>
         <div id="letter-${letter}" style="display:none">
             % for surname in [s for s in surnames if s[0].upper() == letter]:
             <span id="surname-${surname}-button" onclick="show_hide('surname-${surname}')" style="font-size:xx-large">▸</span>
-            <span style="font-size:x-large">${surname}</span>
+            <span style="font-size:x-large" onclick="show_hide('surname-${surname}')">${surname}</span>
             <div id="surname-${surname}" style="display:none">
                 <ul>
                     % for person in [p for p in people_list if p.surname == surname]:
@@ -35,10 +37,8 @@ people_list = sorted(people.values(),key=lambda p:f'{p.surname}, {p.given}')
                     % endfor
                 </ul>
             </div>
-            <br/>
             % endfor
         </div>
-        <br/>
         % endfor
     </body>
 </html>


### PR DESCRIPTION
- All items on a person's page are grouped by year and hidden by default
- <img width="1427" alt="Screenshot 2024-08-08 at 6 04 32 PM" src="https://github.com/user-attachments/assets/644dcfed-22e6-4c9d-a4fd-b678a26e252f">
- Children are sorted by age
- pulled image and inline out into their own templates
- Made nav area people circles like the upper left corner
- Added html head titles to main page and people pages
- Added a visible title to main page
- Clicking on letter or surname now shows/hides that category (in addition to the button)