### PR TITLE
Add alias support

### DIFF
--- a/genweb/genweb.py
+++ b/genweb/genweb.py
@@ -200,7 +200,9 @@ def copy_metadata_files(
 def main() -> None:
     """Generate the website"""
     settings = Settings(__file__)
-    people = People(load_gedcom(settings["gedcom_path"]))
+    people = People(
+        load_gedcom(settings["gedcom_path"]), settings.get("alias_path", None)
+    )
     metadata = load_yaml(settings["metadata_yaml"])
     link_people_to_metadata(people, metadata)
     copy_static_files(settings["copy files"], settings["site_dir"])

--- a/tests/test_people.py
+++ b/tests/test_people.py
@@ -27,14 +27,12 @@ def test_dict_operators() -> None:
 
     gedcom = {p.id: p for p in gedcom_list}
     assert len(gedcom) == len(gedcom_list)
-    people = People(gedcom)
+    people = People(gedcom, None)
     assert "DoeJohnS1973-" in repr(people), repr(people)
     assert people.has_key("DoeJohnS1973-"), people
     assert "DoeJohnS1973-" in people.keys(), people
     assert list(people.values())[0].given == "John Smith", people.values()
     assert list(people.items())[0][0] == list(people.items())[0][1].id, people.items()
-    # people2 = People(gedcom)
-    # assert people == people2, [people, people2]
     assert [i for i in people][0] == "DoeJohnS1973-"
     assert people.get("false", None) is None
     assert people.get("DoeJohnS1973-", None).id == "DoeJohnS1973-"
@@ -56,7 +54,7 @@ def test_middle_initial() -> None:
 
     gedcom = {p.id: p for p in gedcom_list}
     assert len(gedcom) == len(gedcom_list)
-    people = People(gedcom)
+    people = People(gedcom, None)
     assert len(people) == 1, people
     assert "DoeJohnS1973-" in people, people
     assert people["DoeJohnS1973-"].given == "John Smith", people["DoeJohnS1973-"].given
@@ -78,7 +76,7 @@ def test_no_birthdate() -> None:
 
     gedcom = {p.id: p for p in gedcom_list}
     assert len(gedcom) == len(gedcom_list)
-    people = People(gedcom)
+    people = People(gedcom, None)
     assert len(people) == 1, people
     assert "DoeJohnS0000-" in people, people
     assert people["DoeJohnS0000-"].given == "John Smith", people["DoeJohnS0000-"].given
@@ -129,7 +127,7 @@ def test_basic() -> None:
     ]
     gedcom = {p.id: p for p in gedcom_list}
     assert len(gedcom) == len(gedcom_list)
-    people = People(gedcom)
+    people = People(gedcom, None)
     assert len(people) == 4, people
     assert "DoeJohn1973-" in people, people
     assert "SmithSally1971-" in people, people


### PR DESCRIPTION
As person id's are being generated from the GEDCOM file, we check the `alias_path` variable in `genweb.yml` and load a dictionary that maps canonical person id to aliases. If a person id changes (added mother, or learned the year) then you add the old id as the canonical id and map it to the new calculated id. This allows us to update person information without changing the person ids.

# `~/.devopsdriver/genweb.yml`
```yaml
gedcom_path: /Users/marcp/Desktop/myfamily20240805.ged
metadata_yaml: /Users/marcp/Desktop/metadata.yml
site_dir: /Users/marcp/Desktop/FamilyWebsite
binaries_dir: /Users/marcp/Desktop/FamilyHistoryWeb/Individual_Web_Pages
alias_path: /Users/marcp/Desktop/aliases.yml
```

# `~/Desktop/aliases.yml`
```yaml
SmithCatherineM2010PageAmandL1981:
    - SmithCatherineM2010JonesAnnaS0000

SmithSamuelS2012PageAmandL1981:
    - SmithSamuelS2012JonesAnnaS0000

BarrAdaC2018CervenyAndreaM0000:
    - BarrAdaC2018AdamsenAndreaM1987

BarrZoeR2022CervenyAndreaM0000:
    - BarrZoeR2022AdamsenAndreaM1987
```