### PR TITLE
Web Editor: Search for people to put in the people field of metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,16 +89,12 @@ To run the editor:
 
 Here are the current features of the non-functional editor:
 
-- The `Metadata` link will take you to a page that shows all the metadata id's
-- The `People` link will take you to a page that shows all the people id's
-- The person id pop-up demonstrates that a complete menu of all person id's is not workable
-- The metadata id pop-up demonstrates that a complete menu of all metadata id's is not workable
-- Appending a metadata id onto the `Metadata` link will show you the info about the chosen metadata
-- Appending a person id onto the `People` link will show you the info about a person
-- The beige `Search for person id` is a proof-of-concept filter for finder a person id
-- The azure `Copy metadata` is a proof-of-concept filter for finding an existing metadata
 - The metadata type selector should change the appropriate fields shown in the editor for the chosen type
 - If the `Identifier` field is an existing metadata identifier, the submit button changes from `Add` to `Update`
+- Clicking the 🔎 button next to the `People` field will reveal a people search
+- Typing in the people search will filter the people ids
+- Clicking on a person in the filter list will display the person and their family
+- This will allow copy/pasting of people ids into the `People` field
 
 #### webserver.yml
 

--- a/genweb/data/editor.html
+++ b/genweb/data/editor.html
@@ -10,6 +10,19 @@
                 text-align: right;
                 font-weight: bold;
             }
+            .editor {
+                background-color: azure;
+                border-radius: 30px;
+                padding: 30px;
+                display:inline-block;
+            }
+            #people_search {
+                display: inline-block; /* none */
+                background-color:blanchedalmond;
+                border-radius: 30px;
+                padding: 30px;
+                display:inline-block;
+            }
         </style>
         <script>
             const MAXIMUM_TYPE_AHEAD = 50;
@@ -123,28 +136,49 @@
                     submit[0].value = "Add";
                 }
             }
+            function toggle_display(element_id, phase1, phase2) {
+                var element = document.getElementById(element_id);
+
+                if (element.style.display != phase1) {
+                    element.style.display = phase1;
+                } else {
+                    element.style.display = phase2;
+                }
+            }
+            function load_person_into(person, parents, spouses, children) {
+                var request = new XMLHttpRequest();
+                
+                request.onreadystatechange = function() {
+                    if (this.readyState == 4 && this.status == 200) {
+                        var person_info = JSON.parse(request.responseText);
+
+                    }
+                }
+                request.open("GET", "/api/v1/people/" + person_id, true);
+                request.send();
+            }
+            function load_person(person_element_id) {
+                var element = document.getElementById(person_element_id);
+                var person = document.getElementById('person_lookup');
+                var parents = document.getElementById('parents_lookup');
+                var spouses = document.getElementById('spouses_lookup');
+                var children = document.getElementById('children_lookup');
+                
+                person.innerHTML = "";
+                parents.innerHTML = "";
+                spouses.innerHTML = "";
+                children.innerHTML = "";
+
+                if (!server_state.people.includes(element.value)) {
+                    return;  // person not found
+                }
+                load_person_into(person, )
+            }
 
         </script>
     </head>
 	<body class="notranslate" onload="load_values();type_change('type')">
         <h1>genweb editor</h1>
-        API
-        <ul>
-            <li><a href="/api/v1/metadata">Metadata</a></li>
-            <li><a href ="/api/v1/people">People</a></li>
-        </ul>
-        <select name="people" id="people"></select>
-        <select name="metadata" id="metadata"></select>
-        <div style="background-color: beige;border-radius: 15px; padding:30px" width="100">
-            <input id="choose-person" size=40 placeholder="Search for person id" type="text" onkeyup="type_ahead('choose-person', 'people')" onblur="blur_type_ahead('choose-person', 'people')"/>
-            <br/>
-            <select id="choose-person-options" style="display:none" size=5 onchange="select_type_ahead('choose-person')"></select>
-        </div>
-        <div style="background-color: aliceblue;border-radius: 15px; padding:30px" width="100">
-            <input id="choose-metadata" size=40 placeholder="Copy metadata" type="text" onkeyup="type_ahead('choose-metadata', 'metadata')" onblur="blur_type_ahead('choose-metadata', 'metadata')"/>
-            <br/>
-            <select id="choose-metadata-options" style="display:none" size=5 onchange="select_type_ahead('choose-metadata')"></select>
-        </div>
         <div class="editor">
             <table>
                 <tr>
@@ -156,18 +190,103 @@
                         </select>
                     </th>
                 </tr>
-                <tr id="id"><td class="table_label">Identifier</td><td><input placeholder="SurnameNameI0000SurnameNameI0000" size=40 onchange="update_submit_name()"/></td></tr>
-                <tr id="title"><td class="table_label">Title</td><td><input placeholder="Metadata Title" size="75"/></td></tr>
-                <tr id="path"><td class="table_label">Path</td><td><input placeholder="SurnameNameI0000SurnameNameI0000 (owner)" size="40"/></td></tr>
-                <tr id="file"><td class="table_label">File</td><td><input placeholder="SurnameNameI0000SurnameNameI0000.ext" size="40"/></td></tr>
-                <tr id="mod_date"><td class="table_label">Mod Date</td><td><input type="date"/></td></tr>
-                <tr id="people"><td class="table_label">People</td><td><textarea style="overflow-y: scroll;" rows="10" cols="40"></textarea></td></tr>
-                <tr id="folder"><td class="table_label">Folder</td><td><input placeholder="SubsiteFolder" size="40"/></td></tr>
-                <tr id="height"><td class="table_label">Height</td><td><input type="number" min="20" max="10000"/></td></tr>
-                <tr id="width"><td class="table_label">Width</td><td><input type="number" min="20" max="10000"/></td></tr>
-                <tr id="contents"><td class="table_label">Contents</td><td><textarea placeholder="Inline HTML content" rows="10" cols="120"></textarea></td></tr>
-                <tr id="submit"><td></td><td style="text-align: center;"><input value="Add" type="submit"/></td></td></tr>
+                <tr id="id">
+                    <td class="table_label">Identifier</td>
+                    <td>
+                        <input placeholder="SurnameNameI0000SurnameNameI0000" size=40 onchange="update_submit_name()"/>
+                    </td>
+                </tr>
+                <tr id="title">
+                    <td class="table_label">Title</td>
+                    <td><input placeholder="Metadata Title" size="75"/></td>
+                </tr>
+                <tr id="path">
+                    <td class="table_label">Path</td>
+                    <td><input placeholder="SurnameNameI0000SurnameNameI0000 (owner)" size="40"/></td>
+                </tr>
+                <tr id="file">
+                    <td class="table_label">File</td>
+                    <td><input placeholder="SurnameNameI0000SurnameNameI0000.ext" size="40"/></td>
+                </tr>
+                <tr id="mod_date">
+                    <td class="table_label">Mod Date</td>
+                    <td><input type="date"/></td>
+                </tr>
+                <tr id="people">
+                    <td class="table_label">People</td>
+                    <td>
+                        <textarea style="overflow-y: scroll;" rows="10" cols="40"></textarea>
+                        <button onclick="toggle_display('people_search', 'none', 'inline-block')">🔎</button>
+                    </td>
+                </tr>
+                <tr id="folder">
+                    <td class="table_label">Folder</td>
+                    <td><input placeholder="SubsiteFolder" size="40"/></td>
+                </tr>
+                <tr id="height">
+                    <td class="table_label">Height</td>
+                    <td><input type="number" min="20" max="10000"/></td>
+                </tr>
+                <tr id="width">
+                    <td class="table_label">Width</td>
+                    <td><input type="number" min="20" max="10000"/></td>
+                </tr>
+                <tr id="contents">
+                    <td class="table_label">Contents</td>
+                    <td><textarea placeholder="Inline HTML content" rows="10" cols="120"></textarea></td>
+                </tr>
+                <tr id="submit">
+                    <td></td>
+                    <td style="text-align: center;"><input value="Add" type="submit"/></td></td>
+                </tr>
             </table>
         </div>
+        <div id="people_search">
+            <input id="search-person" size=40 placeholder="Search for person id" type="text" onchange="load_person('search-person')" ="type_ahead('search-person', 'people')" onblur="blur_type_ahead('search-person', 'people')"/>
+            <br/>
+            <select id="search-person-options" style="display:none" size=5 onchange="select_type_ahead('search-person')"></select>
+            <ul>
+                <li>
+                    Person
+                    <ul id="person_lookup"></ul>
+                </li>
+                <li>
+                    Parents
+                    <ol id="parents_lookup"></ol>
+                </li>
+                <li>
+                    Spouses
+                    <ol id="spouses_lookup"></ol>
+                </li>
+                <li>
+                    Children
+                    <ol id="children_lookup"></ol>
+                </li>
+            </ul>
+    </div>
+
+        
+        <div style="background-color: gray; padding:30px; border-radius:30px">
+            <h2>Proof of concept and example code</h2>
+
+            API
+            <ul>
+                <li><a href="/api/v1/metadata">Metadata</a></li>
+                <li><a href ="/api/v1/people">People</a></li>
+            </ul>
+            <select name="people" id="people"></select>
+            <select name="metadata" id="metadata"></select>
+            <div style="background-color: beige;border-radius: 15px; padding:30px" width="100">
+                <input id="choose-person" size=40 placeholder="Search for person id" type="text" onkeyup="type_ahead('choose-person', 'people')" onblur="blur_type_ahead('choose-person', 'people')"/>
+                <br/>
+                <select id="choose-person-options" style="display:none" size=5 onchange="select_type_ahead('choose-person')"></select>
+            </div>
+            <div style="background-color: aliceblue;border-radius: 15px; padding:30px" width="100">
+                <input id="choose-metadata" size=40 placeholder="Copy metadata" type="text" onkeyup="type_ahead('choose-metadata', 'metadata')" onblur="blur_type_ahead('choose-metadata', 'metadata')"/>
+                <br/>
+                <select id="choose-metadata-options" style="display:none" size=5 onchange="select_type_ahead('choose-metadata')"></select>
+            </div>
+        </div>
+
     </body>
 </html>

--- a/genweb/data/editor.html
+++ b/genweb/data/editor.html
@@ -14,14 +14,20 @@
                 background-color: azure;
                 border-radius: 30px;
                 padding: 30px;
-                display:inline-block;
+                /*display:inline-block;*/
             }
             #people_search {
-                display: inline-block; /* none */
+                display: none; /* inline-block */
                 background-color:blanchedalmond;
                 border-radius: 30px;
                 padding: 30px;
-                display:inline-block;
+                display: none;
+            }
+            #example-code {
+                display: none;
+                background-color: gray; 
+                padding:30px; 
+                border-radius:30px
             }
         </style>
         <script>
@@ -83,8 +89,8 @@
                 request.send();
             }
             function load_values() {
-                load_into("/api/v1/people", "people", "people");
-                load_into("/api/v1/metadata", "metadata", "metadata");
+                load_into("/api/v1/people", "people", "people_list");
+                load_into("/api/v1/metadata", "metadata", "metadata_list");
             }
             function words_match(words, value) {
                 const word_list = words.split(" ").map((x) => x.toLowerCase());;
@@ -96,10 +102,6 @@
                 if (server_state[field]) {
                     var input = document.getElementById(input_id);
                     var options = document.getElementById(input_id+"-options");
-                    console.log(field);
-                    console.log(server_state[field].length);
-                    console.log(input);
-                    console.log(input.value);
                     const matches = server_state[field].filter(function (i) {
                         return words_match(input.value, i);
                     }).slice(0,MAXIMUM_TYPE_AHEAD);
@@ -145,16 +147,37 @@
                     element.style.display = phase2;
                 }
             }
-            function load_person_into(person, parents, spouses, children) {
+            function load_person_into(person_identifier, person, parents, spouses, children) {
                 var request = new XMLHttpRequest();
                 
                 request.onreadystatechange = function() {
                     if (this.readyState == 4 && this.status == 200) {
                         var person_info = JSON.parse(request.responseText);
+                        var area = document.createElement("li");
 
+                        area.innerHTML = "<b>" + person_info.id + "</b><br/>" 
+                                        + "(" + person_info.gender + ") " + person_info.surname + "," + person_info.given + "<br/>"
+                                        + person_info.birthdate + " - " + person_info.deathdate
+                        person.appendChild(area);
+
+                        if (parents) {
+                            for (var i = 0; i < person_info.parents.length; ++i) {
+                                load_person_into(person_info.parents[i], parents, undefined, undefined, undefined);
+                            }
+                        }
+                        if (spouses) {
+                            for (var i = 0; i < person_info.spouses.length; ++i) {
+                                load_person_into(person_info.spouses[i], spouses, undefined, undefined, undefined);
+                            }
+                        }
+                        if (children) {
+                            for (var i = 0; i < person_info.children.length; ++i) {
+                                load_person_into(person_info.children[i], children, undefined, undefined, undefined);
+                            }
+                        }
                     }
                 }
-                request.open("GET", "/api/v1/people/" + person_id, true);
+                request.open("GET", "/api/v1/people/" + person_identifier, true);
                 request.send();
             }
             function load_person(person_element_id) {
@@ -172,7 +195,8 @@
                 if (!server_state.people.includes(element.value)) {
                     return;  // person not found
                 }
-                load_person_into(person, )
+
+                load_person_into(element.value, person, parents, spouses, children);
             }
 
         </script>
@@ -216,7 +240,7 @@
                     <td class="table_label">People</td>
                     <td>
                         <textarea style="overflow-y: scroll;" rows="10" cols="40"></textarea>
-                        <button onclick="toggle_display('people_search', 'none', 'inline-block')">🔎</button>
+                        <button onclick="toggle_display('people_search', 'block', 'none')">🔎</button>
                     </td>
                 </tr>
                 <tr id="folder">
@@ -242,9 +266,9 @@
             </table>
         </div>
         <div id="people_search">
-            <input id="search-person" size=40 placeholder="Search for person id" type="text" onchange="load_person('search-person')" ="type_ahead('search-person', 'people')" onblur="blur_type_ahead('search-person', 'people')"/>
+            <input id="search-person" size=40 placeholder="Search for person id" type="text" onkeyup="type_ahead('search-person', 'people')" onblur="blur_type_ahead('search-person', 'people')"/>
             <br/>
-            <select id="search-person-options" style="display:none" size=5 onchange="select_type_ahead('search-person')"></select>
+            <select id="search-person-options" style="display:none" size=5 onchange="load_person('search-person-options')"></select>
             <ul>
                 <li>
                     Person
@@ -266,7 +290,7 @@
     </div>
 
         
-        <div style="background-color: gray; padding:30px; border-radius:30px">
+        <div id="example-code">
             <h2>Proof of concept and example code</h2>
 
             API
@@ -274,8 +298,8 @@
                 <li><a href="/api/v1/metadata">Metadata</a></li>
                 <li><a href ="/api/v1/people">People</a></li>
             </ul>
-            <select name="people" id="people"></select>
-            <select name="metadata" id="metadata"></select>
+            <select name="people" id="people_list"></select>
+            <select name="metadata" id="metadata_list"></select>
             <div style="background-color: beige;border-radius: 15px; padding:30px" width="100">
                 <input id="choose-person" size=40 placeholder="Search for person id" type="text" onkeyup="type_ahead('choose-person', 'people')" onblur="blur_type_ahead('choose-person', 'people')"/>
                 <br/>

--- a/genweb/relationships.py
+++ b/genweb/relationships.py
@@ -156,8 +156,8 @@ def person_json(person: SimpleNamespace) -> dict[str, any]:
     return {
         "given": person.given,
         "surname": person.surname,
-        "birthdate": person.birthdate.strftime("%Y-%m-%d"),
-        "deathdate": person.birthdate.strftime("%Y-%m-%d"),
+        "birthdate": person.birthdate.strftime("%Y-%m-%d") if person.birthdate else "?",
+        "deathdate": person.deathdate.strftime("%Y-%m-%d") if person.deathdate else "?",
         "gender": person.gender,
         "id": person.id,
         "spouses": list(person.spouses),

--- a/genweb/webserver.py
+++ b/genweb/webserver.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from os.path import join, dirname
 from json import dumps
 from re import compile as regex
+from traceback import format_exc
 
 from devopsdriver.settings import Settings
 
@@ -68,7 +69,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         assert api_call, self.path
 
         if api_call.group(1) == "people" and not api_call.group(2):
-            people = dumps(list[GLOBALS.people]).encode("utf-8")
+            people = dumps([str(i) for i in GLOBALS.people]).encode("utf-8")
             self.respond(people, mimetype="text/json")
             return
 
@@ -123,7 +124,9 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             )
         except Exception as error:  # pylint: disable=broad-exception-caught
             self.respond(
-                f"Internal server error {error}".encode("utf-8"),
+                f"Internal server error {error}<br/><pre>{format_exc()}</pre>".encode(
+                    "utf-8"
+                ),
                 code=500,
             )
 


### PR DESCRIPTION
### %metadata_yaml% editor

There is an editor in the works, but does not currently work yet.
To run the editor:

1. Add `~/.devopsdriver/webserver.yml` next to `~/.devopsdriver/genweb.yml`
2. Execute `python3 -m genweb.webserver`
3. Point your browser at [localhost:8000](http://localhost:8000)

Here are the current features of the non-functional editor:

- The metadata type selector should change the appropriate fields shown in the editor for the chosen type
- If the `Identifier` field is an existing metadata identifier, the submit button changes from `Add` to `Update`
- Clicking the 🔎 button next to the `People` field will reveal a people search
- Typing in the people search will filter the people ids
- Clicking on a person in the filter list will display the person and their family
- This will allow copy/pasting of people ids into the `People` field

This is part of #36 
<img width="668" alt="Screenshot 2024-08-13 at 8 00 32 AM" src="https://github.com/user-attachments/assets/82e1053c-9d58-45f6-8807-5413adc51d0c">
<img width="994" alt="Screenshot 2024-08-13 at 8 00 42 AM" src="https://github.com/user-attachments/assets/73d7c6c3-aa4b-4888-b7dd-e04d53b026dd">
<img width="661" alt="Screenshot 2024-08-13 at 8 00 50 AM" src="https://github.com/user-attachments/assets/27d7ccf8-13c4-440b-8866-279120b95382">
<img width="703" alt="Screenshot 2024-08-13 at 8 00 57 AM" src="https://github.com/user-attachments/assets/d0b2030d-f97e-41f1-bf2e-69b69c20e460">
<img width="699" alt="Screenshot 2024-08-13 at 8 01 12 AM" src="https://github.com/user-attachments/assets/e6015ba2-ab30-4054-be11-883f9efebad0">


<img width="745" alt="Screenshot 2024-08-13 at 8 18 47 AM" src="https://github.com/user-attachments/assets/0dcbc8b5-1b7f-49be-ab80-2cc94cb7c906">



