### PR TITLE
One step closer to submitting changes via web editor

### DIFF
--- a/genweb/data/editor.html
+++ b/genweb/data/editor.html
@@ -44,6 +44,7 @@
                 "contents"
             ];
             const visible_fields = {
+                id:["inline","href", "picture"],
                 title:["inline", "href", "picture"],
                 path:["inline", "href", "picture"],
                 file:["inline", "href", "picture"],
@@ -280,6 +281,37 @@
                 load_person_into(element.value, person, parents, spouses, children);
             }
 
+            function get_form_json() {
+                var results = {};
+
+                for (var field in visible_fields) {
+                    var value = get_row_input(field);
+
+                    console.log("field = " + field + " value = " + value[0].value);
+                    results[field] = value[0].value;
+                }
+
+                return JSON.stringify(results);
+            }
+
+            function save_form() {
+                var request = new XMLHttpRequest();
+                var form_info = get_form_json();
+                // disable button
+
+                request.onreadystatechange = function() {
+                    if (this.readyState == 4 && this.status == 200) {
+                        // update server state
+                        // enable button
+                        // clear form
+                    }
+                }
+
+                request.open("POST", "/api/v1/metadata/" + form_info.id, true);
+                request.setRequestHeader("Content-Type", "text/json;charset=UTF-8");
+                request.send(form_info);
+            }
+
         </script>
     </head>
 	<body class="notranslate" onload="load_values();type_change('type-selector')">
@@ -349,7 +381,7 @@
                 </tr>
                 <tr id="submit">
                     <td></td>
-                    <td style="text-align: center;"><input value="Add" type="submit"/></td></td>
+                    <td style="text-align: center;"><input value="Add" type="submit" onclick="save_form()"/></td></td>
                 </tr>
             </table>
         </div>

--- a/genweb/genweb.py
+++ b/genweb/genweb.py
@@ -12,7 +12,7 @@ from devopsdriver.settings import Settings
 
 from genweb.relationships import load_gedcom
 from genweb.people import People
-from genweb.metadata import load_yaml
+from genweb.metadata import Metadata
 from genweb.template import render_to_file
 from genweb.inventory import Artifacts
 
@@ -247,7 +247,7 @@ def main() -> None:
     people = People(
         load_gedcom(settings["gedcom_path"]), settings.get("alias_path", None)
     )
-    metadata = load_yaml(settings["metadata_yaml"])
+    metadata = Metadata(settings["metadata_yaml"])
     link_people_to_metadata(people, metadata)
     copy_static_files(settings["copy files"], settings["site_dir"])
     copy_metadata_files(

--- a/genweb/metadata.py
+++ b/genweb/metadata.py
@@ -4,19 +4,10 @@
 """ Hanldes loading and saving of metadta """
 
 
+from glob import glob
+from copy import deepcopy
+
 from yaml import safe_load
-
-
-def validate(metadata: dict[str, dict]) -> dict[str, dict]:
-    """Validates that the metadata is correct
-
-    Args:
-        metadata (dict[str, dict]): The loaded metadata
-
-    Returns:
-        dict[str, dict]: Just returns the metadata so you can chain calls
-    """
-    return metadata
 
 
 def load_yaml(path: str) -> dict[str, dict]:
@@ -32,13 +23,108 @@ def load_yaml(path: str) -> dict[str, dict]:
         return safe_load(file)
 
 
-def load(path: str) -> dict[str, dict]:
-    """Loads a metadata yaml file
+class Metadata:
+    """read-only-dict-like object"""
 
-    Args:
-        path (str): The path to the metadata yaml file
+    def __init__(self, path: str):
+        self.path = path
+        self.original = Metadata.__load(path)
+        self.updated = {}
 
-    Returns:
-        dict[str, dict]: The metadata
-    """
-    return validate(load_yaml(path))
+    @staticmethod
+    def __load(path_pattern: str) -> dict[str:dict]:
+        result = {}
+
+        for path in sorted(glob(path_pattern)):
+            result.update(Metadata.__validate(load_yaml(path)))
+
+        return result
+
+    @staticmethod
+    def __validate(metadata: dict[str:dict]) -> dict[str:dict]:
+        return metadata
+
+    def __combined(self, deep=False) -> dict[str:dict]:
+        if deep:
+            combined = deepcopy(self.original)
+            combined.update(deepcopy(self.updated))
+        else:
+            combined = dict(self.original)
+            combined.update(self.updated)
+
+        return combined
+
+    def __getitem__(self, key: str) -> dict:
+        if key in self.updated:
+            return deepcopy(self.updated[key])
+
+        return deepcopy(self.original[key])
+
+    def __repr__(self) -> str:
+        return repr(self.__combined())
+
+    def __len__(self) -> int:
+        return len(self.__combined())
+
+    def has_key(self, key: str) -> bool:
+        """Is the given identifier available
+
+        Args:
+            key (str): The identifier
+
+        Returns:
+            bool: True if found
+        """
+        return key in self.original or key in self.updated
+
+    def keys(self) -> list[str]:
+        """A list of the identifiers
+
+        Returns:
+            list[str]: The identifiers
+        """
+        return self.__combined().keys()
+
+    def values(self) -> list[dict]:
+        """A list of the people
+
+        Returns:
+            list[dict]: The people
+        """
+        return [deepcopy(v) for v in self.__combined().values()]
+
+    def items(self) -> list[tuple[str, dict]]:
+        """Get a list of pairs of identifiers and people
+
+        Returns:
+            list[tuple(str, dict)]: The identifiers and people
+        """
+        return [(k, deepcopy(v)) for k, v in self.__combined().items()]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.original or key in self.updated
+
+    def __iter__(self):
+        return iter(self.__combined(deep=True))
+
+    def get(self, key: str, default: dict | None = None) -> dict | None:
+        """Gets the person for a given id, or a default person if the id is not found
+
+        Args:
+            key (str): The person's canonical identifier
+            default (dict | None, optional): The person to return if the
+                                                            id is not found. Defaults to None.
+
+        Returns:
+            dict | None: _description_
+        """
+        if key in self.updated:
+            return deepcopy(self.updated[key])
+
+        if key in self.original:
+            return deepcopy(self.original[key])
+
+        return default
+
+    def __setitem__(self, key, item):
+        self.updated[key] = item

--- a/genweb/metadata.py
+++ b/genweb/metadata.py
@@ -26,9 +26,9 @@ def load_yaml(path: str) -> dict[str, dict]:
 class Metadata:
     """read-only-dict-like object"""
 
-    def __init__(self, path: str):
-        self.path = path
-        self.original = Metadata.__load(path)
+    def __init__(self, path_pattern: str):
+        self.path = path_pattern
+        self.original = Metadata.__load(path_pattern)
         self.updated = {}
 
     @staticmethod

--- a/genweb/webserver.py
+++ b/genweb/webserver.py
@@ -163,7 +163,6 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
                 ),
                 code=500,
             )
-            print(format_exc())
 
 
 def start_webserver(port=8000, host="") -> None:

--- a/tests/data/layered.2024-01-01.yml
+++ b/tests/data/layered.2024-01-01.yml
@@ -1,0 +1,29 @@
+0000000000SmithCaleb1765JonesMary1724:
+  file: 0000000000SmithCaleb1765JonesMary1724.src
+  mod_date: '2015-03-21'
+  path: SmithCaleb1765JonesMary1724
+  people:
+  - SmithMargaret1804BrownElisabeth1772
+  - SmithMargaret1802BrownElisabeth1772
+  - SmithGideon1802BrownElisabeth1772
+  - SmithMary1798BrownElisabeth1772
+  - SmithVarnum1796BrownElisabeth1772
+  - SmithJobS1794BrownElisabeth1772
+  - SmithOlive1792BrownElisabeth1772
+  - SmithCalebA1814BrownElisabeth1772
+  - BrownElisabeth1772-
+  - SmithCaleb1765JonesMary1724
+  - StoriesPersonal0000-
+  title: Caleb Smith (1765-1840) Bio
+  type: inline
+
+0000000000JohnsonSamI1892MillerJane1860:
+  file: 0000000000JohnsonSamI1892MillerJane1860.html
+  folder: 0000000000JohnsonSamI1892MillerJane1860
+  mod_date: '2015-03-28'
+  path: JohnsonSamI1892MillerJane1860
+  people:
+  - JohnsonSamI1892MillerJane1860
+  - StoriesPersonal0000-
+  title: Sam I Johnson (1892-1984) Bio
+  type: href

--- a/tests/data/layered.2024-01-05.yml
+++ b/tests/data/layered.2024-01-05.yml
@@ -1,0 +1,18 @@
+0000000000JohnsonSamI1892MillerJane1860:
+  file: 0000000000JohnsonSamI1892MillerJane1860.html
+  folder: 0000000000JohnsonSamI1892MillerJane1860
+  mod_date: '2015-03-28'
+  path: JohnsonSamI1892MillerJane1860
+  people:
+  - JohnsonSamI1892MillerJane1860
+  title: Sam I Johnson (1892-1984) Bio
+  type: href
+
+1700000000WilliamsJohn1665DavisRebecca1639:
+  file: 1700000000WilliamsJohn1665DavisRebecca1639.jpg
+  path: WilliamsJohn1665DavisRebecca1639
+  people:
+  - WilliamsJohn1665DavisRebecca1639
+  title: Williams Home
+  type: picture
+  width: 600


### PR DESCRIPTION
- Created a `Metadata` object that acts like a `dict` 
- Replaced some calls to `load_yaml` with constructing a `Metadata`
- Updated the web editor to submit metadata updates (but not committed to disk yet)
- Print out on web app console the metadata being requested to update
- Got rid of unused `validate` and `load` in `metadata.py`

Part of addressing #36 