### PR TITLE
Web Editor can now save metadata changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ Where `YYYY` is the four-digit year, `MM` is the two-digit month, `DD` is the tw
 
 ### %metadata_yaml% editor
 
-There is an editor in the works, but does not currently work yet.
+There is a web server editor.
 To run the editor:
 
 1. Add `webserver.yml` next to `genweb.yml`
 2. Execute `python3 -m genweb.webserver`
 3. Point your browser at [localhost:8000](http://localhost:8000)
 
-Here are the current features of the non-functional editor:
+Here are the current features of the editor:
 
 - The metadata type selector should change the appropriate fields shown in the editor for the chosen type
 - Clicking the 🔎 button next to the `Identifier` field will allow you to search and load existing metadata
@@ -96,6 +96,7 @@ Here are the current features of the non-functional editor:
 - Typing in the people search will filter the people ids
 - Clicking on a person in the filter list will display the person and their family
 - This will allow copy/pasting of people ids into the `People` field
+- Clicking the `Save` or `Update` button will create a new metadata file next to your existing one
 
 #### webserver.yml
 

--- a/genweb/data/editor.html
+++ b/genweb/data/editor.html
@@ -27,6 +27,8 @@
             }
             
         </style>
+        <!-- MARK: Javascript 
+         -->
         <script>
             const MAXIMUM_TYPE_AHEAD = 50;
             var server_state = {people:undefined, metadata:undefined};
@@ -147,6 +149,7 @@
 
                 input.focus();
             }
+
             function select_type_ahead(input_id) {
                 var input = document.getElementById(input_id);
                 var options = document.getElementById(input_id+"-options");
@@ -169,6 +172,7 @@
 
                 return row_input;
             }
+
             function load_metadata_into(metadata_identifier) {
                 var request = new XMLHttpRequest();
                 
@@ -185,9 +189,12 @@
 
                         for(var field in metadata_info) {
                             var row_input = get_row_input(field);
+                            const field_has_row = (row_input.length > 0);
 
-                            if ( (row_input.length > 0) && field != 'id') {
-                                row_input[0].value = metadata_info[field];
+                            if ( field_has_row && field == 'people') {
+                                row_input[0].value = metadata_info[field].join("\n");
+                            } else if ( field_has_row && field != 'id') {
+                                    row_input[0].value = metadata_info[field];
                             } else {
                                 console.log("Unknown field: " + field + " = " + metadata_info[field]);
                             }
@@ -316,6 +323,8 @@
     </head>
 	<body class="notranslate" onload="load_values();type_change('type-selector')">
         <h1>genweb editor</h1>
+        <!-- MARK: Editor Form
+         -->
         <div class="editor">
             <table>
                 <tr id="type">
@@ -330,7 +339,7 @@
                 <tr id="id">
                     <td class="table_label">Identifier</td>
                     <td>
-                        <input id="choose-metadata" placeholder="SurnameNameI0000SurnameNameI0000" size=40 onchange="update_submit_name()" onkeyup="type_ahead('choose-metadata', 'metadata', false)" onblur="blur_type_ahead('choose-metadata', 'metadata', false)"/>
+                        <input id="choose-metadata" placeholder="YYYYMMDDNNSurnameNameI0000SurnameNameI0000" size=50 onchange="update_submit_name()" onkeyup="type_ahead('choose-metadata', 'metadata', false)" onblur="blur_type_ahead('choose-metadata', 'metadata', false)"/>
                         <button onclick="toggle_display('choose-metadata-options', '', 'none');type_ahead('choose-metadata', 'metadata', false);set_focus('choose-metadata')">🔎</button>
                         <br/>
                         <select id="choose-metadata-options" style="display:none" size=5 onchange="select_type_ahead('choose-metadata');update_submit_name()"></select>
@@ -385,6 +394,9 @@
                 </tr>
             </table>
         </div>
+
+        <!-- MARK: People Search Form
+         -->
         <div id="people_search">
             <input id="search-person" size=40 placeholder="Search for person id" type="text" onkeyup="type_ahead('search-person', 'people', true)" onblur="blur_type_ahead('search-person', 'people', true)"/>
             <br/>

--- a/genweb/data/editor.html
+++ b/genweb/data/editor.html
@@ -298,7 +298,7 @@
                     results[field] = value[0].value;
                 }
 
-                return JSON.stringify(results);
+                return results;
             }
 
             function save_form() {
@@ -316,7 +316,7 @@
 
                 request.open("POST", "/api/v1/metadata/" + form_info.id, true);
                 request.setRequestHeader("Content-Type", "text/json;charset=UTF-8");
-                request.send(form_info);
+                request.send(JSON.stringify(form_info));
             }
 
         </script>

--- a/genweb/webapi_v1.py
+++ b/genweb/webapi_v1.py
@@ -21,6 +21,7 @@ class ApiV1:
     URL = "/api/v1/"
     CALL = regex(rf"^{URL}(people|metadata)(/([^/]+))?$")
     SEPARATOR_PATTERN = regex(r"[\s:;,]+")
+    INT_FIELDS = ["width", "height"]
 
     def __init__(self):
         self.settings: Settings = None
@@ -140,6 +141,10 @@ class ApiV1:
 
             if "people" in metadata:  # change people from string to list
                 metadata["people"] = ApiV1.SEPARATOR_PATTERN.split(metadata["people"])
+
+            for field in ApiV1.INT_FIELDS:
+                if field in metadata:
+                    metadata[field] = int(metadata[field])
 
             self.metadata[identifier] = metadata
             self.metadata.save()

--- a/genweb/webapi_v1.py
+++ b/genweb/webapi_v1.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+""" Module Doc """
+
+
+from http.server import BaseHTTPRequestHandler as Handler
+from json import dumps, loads
+from re import compile as regex
+
+from devopsdriver.settings import Settings
+
+from genweb.relationships import load_gedcom, person_json
+from genweb.people import People
+from genweb.metadata import Metadata
+from genweb.genweb import link_people_to_metadata
+
+
+class ApiV1:
+    """Version 1 of the API"""
+
+    URL = "/api/v1/"
+    CALL = regex(rf"^{URL}(people|metadata)(/([^/]+))?$")
+    SEPARATOR_PATTERN = regex(r"[\s:;,]+")
+
+    def __init__(self):
+        self.settings: Settings = None
+        self.people: People = None
+        self.metadata: Metadata = None
+
+    def load(self, settings: Settings) -> None:
+        """Load all the information needed to run the web server
+
+        Args:
+            location (str): Pass __file__
+        """
+        self.settings = settings
+        self.people = People(
+            load_gedcom(self.settings["gedcom_path"]),
+            self.settings.get("alias_path", None),
+        )
+        self.metadata = Metadata(self.settings["metadata_yaml"])
+        link_people_to_metadata(self.people, self.metadata)
+
+    def parse_call(self, handler: Handler) -> tuple[str | None, str | None]:
+        """Get the category and (possibly) the identifier from the call
+
+        Args:
+            handler (Handler): The HTTP Handler
+
+        Returns:
+            tuple[str | None, str | None]: people or metadata and identifier
+        """
+        parts = ApiV1.CALL.match(handler.path)
+
+        if not parts:
+            return None, None
+
+        return parts.group(1), parts.group(3)
+
+    def is_call(self, handler: Handler) -> bool:
+        """Determines if a request is an API call
+
+        Args:
+            handler (Handler): The HTTP handler
+
+        Returns:
+            bool: True if it is recognized as a possible API call
+        """
+        return self.parse_call(handler)[0] is not None
+
+    def handle_get(self, handler: Handler) -> tuple[bytes, str, int]:
+        """Handles HTTP GET requests
+
+        Args:
+            handler (Handler): The HTTP handler
+
+        Returns:
+            tuple[bytes, str, int]: Returns the body, MIME type, and HTTP response code
+        """
+        category, identifier = self.parse_call(handler)
+        assert category is not None, f"Not an API call {handler.path}"
+        body = None
+        mimetype = "text/json"
+        response_code = 200
+
+        # get the list of people identifiers
+        if category == "people" and not identifier:
+            body = dumps([str(i) for i in self.people]).encode("utf-8")
+
+        # get a specific person
+        elif category == "people" and identifier:
+            person = self.people.get(identifier, None)
+
+            if not person:
+                body = f"Person not found: {identifier}".encode("utf-8")
+                mimetype = "text/plain"
+                response_code = 404
+            else:
+                body = dumps(person_json(person)).encode("utf-8")
+
+        # get the list of metadata identifiers
+        elif category == "metadata" and not identifier:
+            body = dumps(list(self.metadata)).encode("utf-8")
+
+        # get a specific metadata
+        elif category == "metadata" and identifier:
+            if identifier not in self.metadata:
+                body = f"Metadata not found: {identifier}".encode("utf-8")
+                mimetype = "text/plain"
+                response_code = 404
+            else:
+                body = dumps(self.metadata[identifier]).encode("utf-8")
+
+        assert body is not None, f"Not an API call {handler.path}"
+        return body, mimetype, response_code
+
+    def handle_post(self, handler: Handler) -> tuple[bytes, str, int]:
+        """Handles HTTP POST requests
+
+        Args:
+            handler (Handler): The HTTP handler
+
+        Returns:
+            tuple[bytes, str, int]: Returns the body, MIME type, and HTTP response code
+        """
+        category, identifier = self.parse_call(handler)
+        assert category is not None, f"Not an API call {handler.path}"
+        body = None
+        mimetype = "text/json"
+        response_code = 200
+
+        # upload a metadata entry
+        if category == "metadata" and identifier:
+            body_bytes = int(handler.headers["Content-Length"])
+            metadata = loads(handler.rfile.read(body_bytes))
+
+            # delete any empty entries
+            for key in [k for k in metadata if not metadata[k]]:
+                del metadata[key]
+
+            if "people" in metadata:  # change people from string to list
+                metadata["people"] = ApiV1.SEPARATOR_PATTERN.split(metadata["people"])
+
+            self.metadata[identifier] = metadata
+            self.metadata.save()
+            body = dumps(metadata).encode("utf-8")
+
+        assert body is not None, f"Not an API call {handler.path}"
+        return body, mimetype, response_code

--- a/genweb/webserver.py
+++ b/genweb/webserver.py
@@ -5,26 +5,17 @@
 
 
 from http.server import HTTPServer, BaseHTTPRequestHandler
-from types import SimpleNamespace
 from os.path import join, dirname
-from json import dumps, loads
-from re import compile as regex
 from traceback import format_exc
 
 from devopsdriver.settings import Settings
 
-from genweb.relationships import load_gedcom, person_json
-from genweb.people import People
-from genweb.metadata import Metadata
-from genweb.genweb import link_people_to_metadata
+from genweb.webapi_v1 import ApiV1
 
 
-GLOBALS = SimpleNamespace(people=None, metadata=None, settings=None)
+API_V1 = ApiV1()
 DATA_DIR = join(dirname(__file__), "data")
 STATIC_FILES = {"/": "editor.html"}
-API_V1 = "/api/v1/"
-V1_CALL = regex(rf"^{API_V1}(people|metadata)(/([^/]+))?$")
-SEPARATOR_PATTERN = regex(r"[\s:;,]+")
 
 
 class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
@@ -64,78 +55,19 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
                 code=404,
             )
 
-    def handle_api_v1(self, method: str):
-        """Handle any API calls"""
-        api_call = V1_CALL.match(self.path)
-        assert api_call, self.path
-
-        if api_call.group(1) == "people" and not api_call.group(2) and method == "GET":
-            people = dumps([str(i) for i in GLOBALS.people]).encode("utf-8")
-            self.respond(people, mimetype="text/json")
-
-        elif api_call.group(1) == "people" and api_call.group(3) and method == "GET":
-            person = GLOBALS.people.get(api_call.group(3), None)
-
-            if not person:
-                self.respond(
-                    f"Person not found: {api_call.group(3)}".encode("utf-8"), code=404
-                )
-                return
-
-            metadata = dumps(person_json(person)).encode("utf-8")
-            self.respond(metadata, mimetype="text/json")
-
-        elif (
-            api_call.group(1) == "metadata"
-            and not api_call.group(2)
-            and method == "GET"
-        ):
-            people = dumps(list(GLOBALS.metadata)).encode("utf-8")
-            self.respond(people, mimetype="text/json")
-
-        elif api_call.group(1) == "metadata" and api_call.group(3) and method == "GET":
-            if api_call.group(3) not in GLOBALS.metadata:
-                self.respond(
-                    f"Metadata not found: {api_call.group(3)}".encode("utf-8"), code=404
-                )
-                return
-
-            metadata = dumps(GLOBALS.metadata[api_call.group(3)]).encode("utf-8")
-            self.respond(metadata, mimetype="text/json")
-
-        elif api_call.group(1) == "metadata" and api_call.group(3) and method == "POST":
-            metadata = loads(self.rfile.read(int(self.headers["Content-Length"])))
-
-            for key in [k for k in metadata if not metadata[k]]:
-                del metadata[key]
-
-            if "people" in metadata:
-                metadata["people"] = SEPARATOR_PATTERN.split(metadata["people"])
-
-            print(dumps(metadata, indent=2))
-            self.respond(dumps(metadata, indent=2).encode("utf-8"))
-
-        else:
-            self.respond(
-                f"API not found: {self.path}".encode("utf-8"),
-                code=404,
-            )
-
     def do_GET(self):  # pylint: disable=invalid-name
         """Handle GET requests"""
         try:
             if self.path in STATIC_FILES:
                 self.send_file(join(DATA_DIR, STATIC_FILES[self.path]))
-                return
 
-            if self.path.startswith(API_V1):
-                self.handle_api_v1("GET")
-                return
+            elif API_V1.is_call(self):
+                self.respond(*API_V1.handle_get(self))
 
-            self.respond(
-                f"File not found: {self.path}".encode("utf-8"),
-                code=404,
-            )
+            else:
+                body = f"File not found: {self.path}".encode("utf-8")
+                self.respond(body, code=404)
+
         except Exception as error:  # pylint: disable=broad-exception-caught
             self.respond(
                 f"Internal server error {error}<br/><pre>{format_exc()}</pre>".encode(
@@ -147,14 +79,12 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
     def do_POST(self):  # pylint: disable=invalid-name
         """Handle POSTing of data"""
         try:
-            if self.path.startswith(API_V1):
-                self.handle_api_v1("POST")
-                return
+            if API_V1.is_call(self):
+                self.respond(*API_V1.handle_post(self))
 
-            self.respond(
-                f"File not found: {self.path}".encode("utf-8"),
-                code=404,
-            )
+            else:
+                body = f"File not found: {self.path}".encode("utf-8")
+                self.respond(body, code=404)
 
         except Exception as error:  # pylint: disable=broad-exception-caught
             self.respond(
@@ -172,13 +102,7 @@ def start_webserver(port=8000, host="") -> None:
         port (int, optional): The port to listen on. Defaults to 8000.
         host (str, optional): The host to listen on. Defaults to "", meaning all local addresses.
     """
-    GLOBALS.settings = Settings(__file__)
-    GLOBALS.people = People(
-        load_gedcom(GLOBALS.settings["gedcom_path"]),
-        GLOBALS.settings.get("alias_path", None),
-    )
-    GLOBALS.metadata = Metadata(GLOBALS.settings["metadata_yaml"])
-    link_people_to_metadata(GLOBALS.people, GLOBALS.metadata)
+    API_V1.load(Settings(__file__))
     httpd = HTTPServer((host, port), SimpleHTTPRequestHandler)
     print("Starting web server")
     httpd.serve_forever()

--- a/tests/test_webapi_v1.py
+++ b/tests/test_webapi_v1.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+
+
+""" Test the V1 web api """
+
+
+from json import loads, dumps
+from types import SimpleNamespace
+from typing import Self
+from io import BytesIO
+
+from genweb.webapi_v1 import ApiV1
+
+
+class MockHandler:
+    def __init__(self, path):
+        self.path = path
+        self.headers = {}
+        self.rfile = None
+
+    def set_body(self, body: bytes) -> Self:
+        self.headers["Content-Length"] = len(body)
+        self.rfile = BytesIO(body)
+        return self
+
+
+class MockMetadata(dict):
+    def __init__(self, **fields):
+        self.saved = False
+        super().__init__(fields)
+
+    def save(self):
+        self.saved = True
+
+
+def test_list_people() -> None:
+    api = ApiV1()
+    api.settings = {}
+    api.people = {"person1": None, "person2": None}
+    api.metadata = MockMetadata()
+    handler = MockHandler(ApiV1.URL + "people")
+    body, mime, code = api.handle_get(handler)
+    people = loads(body)
+    assert set(people) == set(api.people.keys()), body
+    assert mime == "text/json"
+    assert code == 200
+    assert not api.metadata.saved
+
+
+def test_list_metadata() -> None:
+    api = ApiV1()
+    api.settings = {}
+    api.people = {}
+    api.metadata = MockMetadata(metadata1=None, metadata2=None)
+    handler = MockHandler(ApiV1.URL + "metadata")
+    body, mime, code = api.handle_get(handler)
+    metadata = loads(body)
+    assert set(metadata) == set(api.metadata.keys()), body
+    assert mime == "text/json"
+    assert code == 200
+    assert not api.metadata.saved
+
+
+def test_get_person() -> None:
+    api = ApiV1()
+    api.settings = {}
+    api.people = {
+        "person1": SimpleNamespace(
+            given="John Albert",
+            surname="Doe",
+            birthdate=None,
+            deathdate=None,
+            gender="M",
+            id="person1",
+            spouses=[],
+            children=[],
+            parents=[],
+            metadata=[],
+        ),
+        "person2": SimpleNamespace(),
+    }
+    api.metadata = MockMetadata()
+    handler = MockHandler(ApiV1.URL + "people/person1")
+    body, mime, code = api.handle_get(handler)
+    person = loads(body)
+    assert person["given"] == api.people["person1"].given, body
+    assert person["surname"] == api.people["person1"].surname, body
+    assert person["gender"] == api.people["person1"].gender, body
+    assert mime == "text/json"
+    assert code == 200
+    assert not api.metadata.saved
+
+
+def test_get_metadata() -> None:
+    api = ApiV1()
+    api.settings = {}
+    api.people = {}
+    api.metadata = MockMetadata(metadata1={"a": 1, "b": 2}, metadta2={"c": 3, "d": 4})
+    handler = MockHandler(ApiV1.URL + "metadata/metadata1")
+    body, mime, code = api.handle_get(handler)
+    metadata = loads(body)
+    assert metadata == api.metadata["metadata1"]
+    assert mime == "text/json"
+    assert code == 200
+    assert not api.metadata.saved
+
+
+def test_post_metadata() -> None:
+    api = ApiV1()
+    api.settings = {}
+    api.people = {}
+    api.metadata = MockMetadata()
+    handler = MockHandler(ApiV1.URL + "metadata/metadata1")
+    post_metadata = {"a": 1, "b": 2, "people": "a,b, c\r\nd\ne f;g:h", "c": ""}
+    handler.set_body(dumps(post_metadata).encode("utf-8"))
+    body, mime, code = api.handle_post(handler)
+    metadata = loads(body)
+    assert set(metadata) == set(post_metadata) - {"c"}, body
+    assert metadata["a"] == post_metadata["a"], body
+    assert metadata["b"] == post_metadata["b"], body
+    assert "c" not in metadata, body
+    assert set(metadata["people"]) == set("abcdefgh"), body
+    assert mime == "text/json"
+    assert code == 200
+    assert api.metadata.saved
+
+
+def test_non_api() -> None:
+    api = ApiV1()
+    api.settings = {}
+    api.people = {}
+    api.metadata = MockMetadata()
+    handler = MockHandler(ApiV1.URL + "bogus")
+
+    try:
+        _, _, _ = api.handle_post(handler)
+        raise AssertionError("Expected exception")
+
+    except AssertionError:
+        pass
+
+    try:
+        _, _, _ = api.handle_get(handler)
+        raise AssertionError("Expected exception")
+
+    except AssertionError:
+        pass
+
+    handler = MockHandler(ApiV1.URL + "bogus/identifier")
+
+    try:
+        _, _, _ = api.handle_post(handler)
+        raise AssertionError("Expected exception")
+
+    except AssertionError:
+        pass
+
+    try:
+        _, _, _ = api.handle_get(handler)
+        raise AssertionError("Expected exception")
+
+    except AssertionError:
+        pass
+
+    handler = MockHandler(ApiV1.URL + "metadata/identifier/")
+
+    try:
+        _, _, _ = api.handle_post(handler)
+        raise AssertionError("Expected exception")
+
+    except AssertionError:
+        pass
+
+    try:
+        _, _, _ = api.handle_get(handler)
+        raise AssertionError("Expected exception")
+
+    except AssertionError:
+        pass
+
+    handler = MockHandler(ApiV1.URL + "metadata/")
+
+    try:
+        _, _, _ = api.handle_post(handler)
+        raise AssertionError("Expected exception")
+
+    except AssertionError:
+        pass
+
+    try:
+        _, _, _ = api.handle_get(handler)
+        raise AssertionError("Expected exception")
+
+    except AssertionError:
+        pass
+
+    handler = MockHandler(ApiV1.URL + "metadata/identifier/bogus")
+
+    try:
+        _, _, _ = api.handle_post(handler)
+        raise AssertionError("Expected exception")
+
+    except AssertionError:
+        pass
+
+    try:
+        _, _, _ = api.handle_get(handler)
+        raise AssertionError("Expected exception")
+
+    except AssertionError:
+        pass
+
+
+def test_metadata_404() -> None:
+    api = ApiV1()
+    api.settings = {}
+    api.people = {}
+    api.metadata = MockMetadata(metadata1={"a": 1, "b": 2}, metadta2={"c": 3, "d": 4})
+    handler = MockHandler(ApiV1.URL + "metadata/metadata5")
+    body, mime, code = api.handle_get(handler)
+    assert code == 404
+    assert not api.metadata.saved
+
+
+def test_person_404() -> None:
+    api = ApiV1()
+    api.settings = {}
+    api.people = {"person1": SimpleNamespace(), "person2": SimpleNamespace()}
+    api.metadata = MockMetadata()
+    handler = MockHandler(ApiV1.URL + "people/person5")
+    body, mime, code = api.handle_get(handler)
+    assert code == 404
+    assert not api.metadata.saved
+
+
+def test_is_call() -> None:
+    api = ApiV1()
+    api.settings = {}
+    api.people = {}
+    api.metadata = MockMetadata()
+    assert api.is_call(MockHandler(ApiV1.URL + "people"))
+    assert api.is_call(MockHandler(ApiV1.URL + "metadata"))
+    assert not api.is_call(MockHandler(ApiV1.URL + "bogus"))
+    assert api.is_call(MockHandler(ApiV1.URL + "people/person1"))
+    assert api.is_call(MockHandler(ApiV1.URL + "metadata/metadata1"))
+    assert not api.is_call(MockHandler(ApiV1.URL + "bogus/bogus1"))
+    assert not api.is_call(MockHandler(ApiV1.URL))
+    assert not api.is_call(MockHandler(ApiV1.URL + "people/"))
+    assert not api.is_call(MockHandler(ApiV1.URL + "metadata/"))
+    assert not api.is_call(MockHandler(ApiV1.URL + "people/person1/"))
+    assert not api.is_call(MockHandler(ApiV1.URL + "metadata/metadata1/"))
+
+
+if __name__ == "__main__":
+    test_list_people()
+    test_list_metadata()
+    test_get_person()
+    test_get_metadata()
+    test_post_metadata()
+    test_non_api()
+    test_metadata_404()
+    test_person_404()
+    test_is_call()

--- a/tests/test_webapi_v1.py
+++ b/tests/test_webapi_v1.py
@@ -6,7 +6,6 @@
 
 from json import loads, dumps
 from types import SimpleNamespace
-from typing import Self
 from io import BytesIO
 
 from genweb.webapi_v1 import ApiV1
@@ -18,7 +17,7 @@ class MockHandler:
         self.headers = {}
         self.rfile = None
 
-    def set_body(self, body: bytes) -> Self:
+    def set_body(self, body: bytes):
         self.headers["Content-Length"] = len(body)
         self.rfile = BytesIO(body)
         return self


### PR DESCRIPTION
- Refactored API out into its own file
- Implemented metadata save from web editor

### %metadata_yaml% editor

There is a web server editor.
To run the editor:

1. Add `webserver.yml` next to `genweb.yml`
2. Execute `python3 -m genweb.webserver`
3. Point your browser at [localhost:8000](http://localhost:8000)

Here are the current features of the editor:

- The metadata type selector should change the appropriate fields shown in the editor for the chosen type
- Clicking the 🔎 button next to the `Identifier` field will allow you to search and load existing metadata
- If the `Identifier` field is an existing metadata identifier, the submit button changes from `Add` to `Update`
- Clicking the 🔎 button next to the `People` field will reveal a people search
- Typing in the people search will filter the people ids
- Clicking on a person in the filter list will display the person and their family
- This will allow copy/pasting of people ids into the `People` field
- Clicking the `Save` or `Update` button will create a new metadata file next to your existing one

This closes #36 