### PR TITLE
Move logic for file to copy for metadata to metadata

### DIFF
--- a/genweb/cleanup.py
+++ b/genweb/cleanup.py
@@ -20,8 +20,9 @@ from re import compile as regex, DOTALL
 
 from devopsdriver.settings import Settings, load_yaml
 
-
 DRY_RUN = "-n" in argv
+MAKEDIRS = makedirs
+MOVE = move
 
 
 def unique_trash_name(path: str) -> str:
@@ -54,7 +55,6 @@ def pref() -> tuple[str, str]:
     settings = load_yaml(join(Settings.PREF_DIR[os_system()], "genweb.yml"))
     cleanup_dir = settings["binaries_dir"]
     trash_dir = join(dirname(dirname(cleanup_dir)), basename(cleanup_dir) + "_trash")
-    makedirs(trash_dir, exist_ok=True)
     return (cleanup_dir, trash_dir)
 
 
@@ -71,7 +71,7 @@ def trash(relative: str):
         return
 
     destination = unique_trash_name(join(trash_dir, relative))
-    makedirs(dirname(destination), exist_ok=True)
+    MAKEDIRS(dirname(destination), exist_ok=True)
 
     if DRY_RUN:
         print("DRY RUN:")
@@ -79,7 +79,7 @@ def trash(relative: str):
         print(f"\t   TO: {destination}")
         return
 
-    move(path, destination)
+    MOVE(path, destination)
 
 
 def patchup(patchup_list: list[tuple]):

--- a/genweb/inventory.py
+++ b/genweb/inventory.py
@@ -38,6 +38,17 @@ class Artifacts:
         """
         return [f for f in self.accounted | self.unaccounted if basename(f) == filename]
 
+    def suffixed(self, suffix: str) -> list[str]:
+        """Finds all relative file paths that end with the given suffix
+
+        Args:
+            suffix (str): The end of the path to look for (may include path separators)
+
+        Returns:
+            list[str]: The list of relative paths that end with the given suffix
+        """
+        return [f for f in self.accounted | self.unaccounted if f.endswith(suffix)]
+
     def has_file(self, file_path: str) -> bool:
         """See if this file exists
 

--- a/genweb/metadata.py
+++ b/genweb/metadata.py
@@ -61,7 +61,7 @@ class Metadata:
     def _inline_copy_list(  # pylint: disable=unused-argument
         inline: dict, artifacts: Artifacts
     ) -> list[tuple[str, str]]:
-        return []
+        return []  # TODO: detect files to copy from contents  # pylint: disable=fixme
 
     @staticmethod
     def _picture_copy_list(pict: dict, artifacts: Artifacts) -> list[tuple[str, str]]:

--- a/genweb/people.py
+++ b/genweb/people.py
@@ -18,7 +18,8 @@ class People:
     """A read-only dictionary like object that maps identifier to people"""
 
     def __init__(self, people: dict[str, SimpleNamespace], alias_path: str):
-        self.aliases = load_yaml(alias_path) if alias_path else {}
+        aliases = load_yaml(alias_path) if alias_path else {}
+        self.aliases = aliases if aliases else {}
         self.by_id = self._remap(people, self.aliases)
 
     def cannonical_id(self, identifier: str) -> str:

--- a/tests/data/aliases.yml
+++ b/tests/data/aliases.yml
@@ -1,0 +1,7 @@
+
+DoeJohnS1973-:
+  - DoeJohnS1973SmithSally1953
+  - DoeJohnS1973SmithSally0000
+
+SmithSally1953-:
+  - SmithSally1953JonesJaneL1933

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+""" noops to remove cleanup from test coverage output """
+
+
+import genweb.cleanup
+
+
+def run_cleanup() -> None:
+    genweb.cleanup.DRY_RUN = True
+    genweb.cleanup.MAKEDIRS = lambda d: d
+    genweb.cleanup.MOVE = lambda s, d: (s, d)
+    genweb.cleanup.main()
+    genweb.cleanup.DRY_RUN = False
+    genweb.cleanup.main()
+
+
+if __name__ == "__main__":
+    run_cleanup()

--- a/tests/test_genweb.py
+++ b/tests/test_genweb.py
@@ -70,6 +70,15 @@ def test_copy_static_files() -> None:
         assert isfile(join(working_dir, "images", "unknown.jpg"))
 
 
+class MockMetadata(dict):
+    def __init__(self, contents: dict, copy_list: list[tuple[str, str]]):
+        self.copy_list = copy_list
+        super().__init__(contents)
+
+    def get_copy_list(self, _: Artifacts) -> list[tuple[str, str]]:
+        return self.copy_list
+
+
 def test_copy_metadata_files() -> None:
     genweb.genweb.PRINT = lambda _: None
 
@@ -81,11 +90,16 @@ def test_copy_metadata_files() -> None:
             join(dst_dir, "foo", "test.xml"),
         )
         artifacts = Artifacts(src_dir)
-        metadata = {
-            "1": {"type": "picture", "file": "test.xml", "path": "foo"},
-            "2": {"type": "unknown"},
-            "3": {"type": "picture", "file": "missing.xml", "path": "bar"},
-        }
+        metadata = MockMetadata(
+            {
+                "1": {"type": "picture", "file": "test.xml", "path": "foo"},
+                "2": {"type": "unknown"},
+                "3": {"type": "picture", "file": "missing.xml", "path": "bar"},
+            },
+            [
+                ("data/test.xml", "foot/test.xml"),
+            ],
+        )
         people = {
             "1": SimpleNamespace(id="1", metadata=["1"]),
             "fake": SimpleNamespace(id="fake", metadata=["1"]),

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -9,6 +9,11 @@ from os.path import dirname, relpath, basename
 from genweb.inventory import Artifacts
 
 
+def test_suffixed() -> None:
+    artifacts = Artifacts(dirname(__file__))
+    assert "data/fake.jpg" in artifacts.suffixed("ta/fake.jpg")
+
+
 def test_basic() -> None:
     artifacts = Artifacts(dirname(__file__))
     assert relpath(__file__, artifacts.directory) in artifacts.lost(), [
@@ -58,3 +63,4 @@ def test_basic() -> None:
 
 if __name__ == "__main__":
     test_basic()
+    test_suffixed()

--- a/tests/test_people.py
+++ b/tests/test_people.py
@@ -6,9 +6,48 @@
 
 from types import SimpleNamespace
 from datetime import date
+from os.path import join, dirname
 
 from genweb.people import People
 import genweb.people
+
+
+DATA_DIR = join(dirname(__file__), "data")
+
+
+def test_aliases() -> None:
+    gedcom_list = [
+        SimpleNamespace(
+            id="2",
+            given="Sally",
+            surname="Smith",
+            gender="F",
+            birthdate=date(1953, 3, 20),
+            parents=set(),
+            spouses=set(),
+            children=set(),
+        ),
+        SimpleNamespace(
+            id="1",
+            given="John Smith",
+            surname="Doe",
+            gender="M",
+            birthdate=date(1973, 6, 30),
+            parents=set("2"),
+            spouses=set(),
+            children=set(),
+        ),
+    ]
+
+    gedcom = {p.id: p for p in gedcom_list}
+    assert len(gedcom) == len(gedcom_list)
+    people = People(gedcom, join(DATA_DIR, "aliases.yml"))
+    assert "DoeJohnS1973-" in people
+    assert "DoeJohnS1973SmithSally1953" in people
+    assert "DoeJohnS1973SmithSally0000" in people
+    assert people["DoeJohnS1973-"] == people["DoeJohnS1973SmithSally1953"]
+    assert people["DoeJohnS1973-"] == people["DoeJohnS1973SmithSally0000"]
+    assert "DoeJohnS1973-" in people.keys()
 
 
 def test_dict_operators() -> None:
@@ -164,3 +203,4 @@ if __name__ == "__main__":
     test_middle_initial()
     test_no_birthdate()
     test_find_mother()
+    test_aliases()


### PR DESCRIPTION
The logic for what files comes from the metadata should be in the `Metadata` object

preparing for #42