### PR TITLE
Calling `make format` will now update the code coverage number in `README.md`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY:clean venv test coverage lint format deploy
 all:clean test coverage lint
 
-MIN_TEST_COVERAGE=65
+MIN_TEST_COVERAGE=70
 INITIAL_PYTHON?=python3
 VENV_DIR?=.venv
 LIBRARY=genweb
@@ -47,10 +47,10 @@ coverage: $(COVERAGE_FILE)
 $(FORMAT_FILE): $(VENV_DIR)/touchfile $(SOURCES)
 	@$(SET_ENV); $(PIP_INSTALL) ".[dev]"
 	@$(SET_ENV); $(VENV_PYTHON) -m black $(LIBRARY) &> $@
-	@perl -i -pe's/test\+coverage\&message=..%/test\+coverage\&message=$(MIN_TEST_COVERAGE)%/g' README.md
 
 format: $(FORMAT_FILE)
 	@cat $^
+	@perl -i -pe's/test\+coverage\&message=..%/test\+coverage\&message=$(MIN_TEST_COVERAGE)%/g' README.md
 
 $(LINT_FILE): $(VENV_DIR)/touchfile $(SOURCES)
 	@$(SET_ENV); $(PIP_INSTALL) ".[dev]"

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ coverage: $(COVERAGE_FILE)
 $(FORMAT_FILE): $(VENV_DIR)/touchfile $(SOURCES)
 	@$(SET_ENV); $(PIP_INSTALL) ".[dev]"
 	@$(SET_ENV); $(VENV_PYTHON) -m black $(LIBRARY) &> $@
+	@perl -i -pe's/test\+coverage\&message=..%/test\+coverage\&message=$(MIN_TEST_COVERAGE)%/g' README.md
 
 format: $(FORMAT_FILE)
 	@cat $^

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![size sheild](https://img.shields.io/github/languages/code-size/marcpage/genweb?style=plastic)](https://github.com/marcpage/genweb)
 
 [![example workflow](https://github.com/marcpage/genweb/actions/workflows/CI.yml/badge.svg)](https://github.com/marcpage/genweb/actions/workflows/CI.yml)
-[![status sheild](https://img.shields.io/static/v1?label=test+coverage&message=65%&color=active&style=plastic)](https://github.com/marcpage/genweb/blob/main/Makefile#L4)
+[![status sheild](https://img.shields.io/static/v1?label=test+coverage&message=70%&color=active&style=plastic)](https://github.com/marcpage/genweb/blob/main/Makefile#L4)
 [![issues sheild](https://img.shields.io/github/issues-raw/marcpage/genweb?style=plastic)](https://github.com/marcpage/genweb/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/marcpage/genweb?style=flat)](https://github.com/marcpage/genweb/pulls)
 


### PR DESCRIPTION
Before this change when you needed to update the minimum code coverage percent you needed to modify `MIN_TEST_COVERAGE` at the top of the `Makefile` and some obscure number hidden in a link in the `README.md`.

After this change, you just need to update `MIN_TEST_COVERAGE` at the top of the `Makefile` and then call `make format` and it will copy the value from `MIN_TEST_COVERAGE` into the `README.md` for you.

Also updated the minimum test coverage from 65% to 70% to test (currently we are at 74% coverage)