### PR TITLE
Inline elements now copy artifact files they reference

### DIFF
--- a/tests/data/example.yml
+++ b/tests/data/example.yml
@@ -28,6 +28,28 @@
   title: Sam I Johnson (1892-1984) Bio
   type: href
 
+0000000001JohnsonSamI1892MillerJane1860:
+  file: 0000000001JohnsonSamI1892MillerJane1860.src
+  mod_date: '2015-03-28'
+  path: JohnsonSamI1892MillerJane1860
+  people:
+  - JohnsonSamI1892MillerJane1860
+  - StoriesPersonal0000-
+  title: Sam I Johnson (1892-1984) Bio
+  contents: |
+    Inline html with <img src="../media/image.jpg"/> images.
+  type: inline
+
+0000000002JohnsonSamI1892MillerJane1860:
+  file: 0000000002JohnsonSamI1892MillerJane1860.src
+  mod_date: '2015-03-28'
+  path: JohnsonSamI1892MillerJane1860
+  people:
+  - JohnsonSamI1892MillerJane1860
+  - StoriesPersonal0000-
+  title: Sam I Johnson (1892-1984) Bio
+  type: href
+
 1700000000WilliamsJohn1665DavisRebecca1639:
   file: 1700000000WilliamsJohn1665DavisRebecca1639.jpg
   path: WilliamsJohn1665DavisRebecca1639

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -111,7 +111,7 @@ def test_metadata() -> None:
 
 def test_load_yaml() -> None:
     metadata = load_yaml(join(DATA_DIR, "example.yml"))
-    assert len(metadata) == 3, ",".join(metadata.keys())
+    assert len(metadata) == 5, ",".join(metadata.keys())
     assert "0000000000SmithCaleb1765JonesMary1724" in metadata
     assert len(metadata["0000000000SmithCaleb1765JonesMary1724"]["people"]) == 11
     assert (


### PR DESCRIPTION
We now parse the inline html looking for `<a>`, `<img>`, or `<source>` tags that have one of these extensions: `.epub`, `.gif`, `.jpeg`, `.jpg`, `.mov`, `.mp3`, `.mp4`, `.pdf`, or `.png` in their `src`, `alt`, `href`, `background`, `name`, or `title` attribute.

We then look for that file in the artifacts directory and if found, copy (hard link) that file to the equivalent destination in the output directory.

Closes #42 