### PR TITLE
Adding links to originals

### DIFF
--- a/genweb/cleanup.py
+++ b/genweb/cleanup.py
@@ -82,6 +82,20 @@ def trash(relative: str):
     MOVE(path, destination)
 
 
+def remove_todo():
+    """Trash directories named ToDo"""
+    cleanup_dir, _ = pref()
+    remove = [
+        relpath(join(r, d), cleanup_dir)
+        for r, ds, _ in walk(cleanup_dir)
+        for d in ds
+        if d.lower() == "todo"
+    ]
+
+    for path in remove:
+        trash(path)
+
+
 def patchup(patchup_list: list[tuple]):
     """Given a list of file extension, regex, replacement, and description, apply them to files.
         If
@@ -131,6 +145,7 @@ def patchup(patchup_list: list[tuple]):
 def main() -> None:
     """parses the directories and makes known needed fixes"""
     trash("PedigreeCharts")
+    remove_todo()
     patchup(
         [
             (

--- a/genweb/metadata.py
+++ b/genweb/metadata.py
@@ -6,9 +6,8 @@
 
 from glob import glob
 from copy import deepcopy
-from os.path import splitext, join, relpath, normpath
+from os.path import splitext, join, relpath
 from datetime import datetime
-from re import compile as regex, DOTALL
 
 from yaml import safe_load, safe_dump
 
@@ -34,22 +33,6 @@ class Metadata:
     Revisions saved earlier are preserved, but overridden by later revisions
     """
 
-    PATH_PATTERN = regex(
-        r'<(a|img|source)[^>]+(src|alt|href|background|name|title)="([^"]+)"', DOTALL
-    )
-    INVALID_PATTERN = regex(r"^(#|https?://|mailto:)")
-    VALID_EXTENSIONS = {
-        ".epub",
-        ".gif",
-        ".jpeg",
-        ".jpg",
-        ".mov",
-        ".mp3",
-        ".mp4",
-        ".pdf",
-        ".png",
-    }
-
     def __init__(self, path: str):
         self.path = path  # original file
 
@@ -72,25 +55,16 @@ class Metadata:
 
     @staticmethod
     def _inline_copy_list(inline: dict, artifacts: Artifacts) -> list[tuple[str, str]]:
-        if "contents" not in inline:
-            return []  # TODO: handle in validate href  # pylint: disable=fixme
+        if "references" not in inline:
+            return []
 
         found = []
-        paths = [
-            m.group(3).strip()
-            for m in Metadata.PATH_PATTERN.finditer(inline["contents"])
-            if not Metadata.INVALID_PATTERN.match(m.group(3).strip())
-            and splitext(m.group(3))[1].lower() in Metadata.VALID_EXTENSIONS
-        ]
 
-        for path in paths:
-            item_src = normpath(join(inline["path"], path))
-            item_dst = normpath(join(inline["path"], path))
-
-            if not artifacts.has_file(item_src):
+        for referenced in inline["references"]:
+            if not artifacts.has_file(referenced):
                 continue  # TODO: handle in validate  # pylint: disable=fixme
 
-            found.append((item_src, item_dst))
+            found.append((referenced, referenced))
 
         return found
 
@@ -98,11 +72,25 @@ class Metadata:
     def _picture_copy_list(pict: dict, artifacts: Artifacts) -> list[tuple[str, str]]:
         picture_src = join(pict["path"], pict["file"])
         picture_dst = join(pict["path"], pict["file"])
+        found = []
 
         if not artifacts.has_file(picture_src):
             return []  # TODO: handle in validate pict  # pylint: disable=fixme
 
-        return [(picture_src, picture_dst)]
+        found.append((picture_src, picture_dst))
+
+        if not "original" in pict:
+            return found
+
+        original_src = join(pict["path"], pict["original"])
+        original_dst = join(pict["path"], pict["original"])
+
+        if not artifacts.has_file(original_src):
+            return found  # TODO: handle in validate pict  # pylint: disable=fixme
+
+        found.append((original_src, original_dst))
+
+        return found
 
     @staticmethod
     def _href_copy_list(href: dict, artifacts: Artifacts) -> list[tuple[str, str]]:

--- a/genweb/templates/picture.html.mako
+++ b/genweb/templates/picture.html.mako
@@ -14,6 +14,11 @@
                 <tr>
                     <td ALIGN="CENTER" VALIGN="TOP">
                         <img src="../${element["path"]}/${element["file"]}" target="Resource Window">
+                        % if "original" in element:
+                        <a href="../${element["path"]}/${element["original"]}" target="Resource Window">
+                        <font size="18"> &#x1F50D;</font>
+                        </a>
+                        % endif
                     </td>
                 </tr>
                 <tr>

--- a/tests/data/example.yml
+++ b/tests/data/example.yml
@@ -38,6 +38,8 @@
   title: Sam I Johnson (1892-1984) Bio
   contents: |
     Inline html with <img src="../media/image.jpg"/> images.
+  references:
+  - media/image.jpg
   type: inline
 
 0000000002JohnsonSamI1892MillerJane1860:
@@ -57,5 +59,15 @@
   people:
   - WilliamsJohn1665DavisRebecca1639
   title: Williams Home
+  original: +1700000000WilliamsJohn1665DavisRebecca1639.jpg
   type: picture
   width: 600
+
+1700000001WilliamsJohn1665DavisRebecca1639:
+  file: 1700000001WilliamsJohn1665DavisRebecca1639.jpg
+  path: WilliamsJohn1665DavisRebecca1639
+  people:
+  - WilliamsJohn1665DavisRebecca1639
+  title: Williams Home
+  type: picture
+  height: 300

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -111,7 +111,7 @@ def test_metadata() -> None:
 
 def test_load_yaml() -> None:
     metadata = load_yaml(join(DATA_DIR, "example.yml"))
-    assert len(metadata) == 5, ",".join(metadata.keys())
+    assert len(metadata) == 6, ",".join(metadata.keys())
     assert "0000000000SmithCaleb1765JonesMary1724" in metadata
     assert len(metadata["0000000000SmithCaleb1765JonesMary1724"]["people"]) == 11
     assert (
@@ -126,11 +126,15 @@ class MockArtifacts:
     def __init__(self):
         self.has_dir_result = True
         self.has_file_result = True
+        self.has_file_plus_result = True
 
     def has_dir(self, path: str) -> bool:
         return self.has_dir_result
 
     def has_file(self, path: str) -> bool:
+        if "/+" in path:
+            return self.has_file_plus_result
+
         return self.has_file_result
 
     def files_under(self, path: str) -> list:
@@ -140,6 +144,8 @@ class MockArtifacts:
 def test_get_copy_list() -> None:
     metadata = Metadata(join(DATA_DIR, "example.yml"))
     artifacts = MockArtifacts()
+    _ = metadata.get_copy_list(artifacts)
+    artifacts.has_file_plus_result = False
     _ = metadata.get_copy_list(artifacts)
     artifacts.has_file_result = False
     _ = metadata.get_copy_list(artifacts)

--- a/tests/test_parse_metdata.py
+++ b/tests/test_parse_metdata.py
@@ -3,11 +3,12 @@
 """ Test functionality in parsing the metadata """
 
 
+from os import makedirs
 from os.path import join, dirname
 from tempfile import TemporaryDirectory
 
 from genweb.parse_metadata import read_xml, validate_settings, load_metadata
-from genweb.parse_metadata import load_inlines
+from genweb.parse_metadata import load_external
 
 from genweb import parse_metadata
 
@@ -76,14 +77,15 @@ def test_load_inlines() -> None:
 
     with TemporaryDirectory() as working_dir:
         metadata = {
-            "1": {"file": "inline.src", "type": "inline"},
-            "2": {"file": "missing.src", "type": "inline"},
+            "1": {"file": "inline.src", "path": "1", "type": "inline"},
+            "2": {"file": "missing.src", "path": "2", "type": "inline"},
         }
+        makedirs(join(working_dir, "1"))
 
-        with open(join(working_dir, "inline.src"), "w", encoding="utf-8") as file:
+        with open(join(working_dir, "1", "inline.src"), "w", encoding="utf-8") as file:
             file.write("the inline contents")
 
-        load_inlines(metadata, working_dir)
+        load_external(metadata, working_dir)
         assert metadata["1"]["contents"] == "the inline contents", [
             metadata["1"]["contents"]
         ]


### PR DESCRIPTION
- Moving logic to find images (originals and inline references) to `parse_metadata.py`
- Updating the template to conditionally add the magnifying glass and link to original ("+" image file)
- Added "references" key to `inline` metadata type to direct which files to copy to support the inline
- Added "original" key to `picture` metadata to indicate there is an original file ("+")
- Removed all "ToDo" folders with `cleanup.py`
- Loading inline .src files directly by path instead of searching for them

Closes #35 