### PR TITLE
Users/marcp/update web editor for inline references and picture originals

### DIFF
--- a/genweb/data/editor.html
+++ b/genweb/data/editor.html
@@ -116,8 +116,12 @@
                     <ol id="children_lookup"></ol>
                 </li>
             </ul>
-    </div>
+        </div>
 
-        
+        <div id="error_area" style="display:none">
+            <h2>Errors</h2>
+            <textarea id="errors" style="overflow-y: scroll;" rows="40" cols="120" readonly></textarea>
+        </div>
+
     </body>
 </html>

--- a/genweb/data/editor.html
+++ b/genweb/data/editor.html
@@ -63,6 +63,10 @@
                     <td class="table_label">Folder</td>
                     <td><input placeholder="SubsiteFolder" size="40"/></td>
                 </tr>
+                <tr id="original">
+                    <td class="table_label">Original</td>
+                    <td><input placeholder="+SurnameNameI0000SurnameNameI0000.jpg" size="50"/></td>
+                </tr>
                 <tr id="height">
                     <td class="table_label">Height</td>
                     <td><input type="number" min="20" max="10000"/></td>
@@ -75,9 +79,15 @@
                     <td class="table_label">Contents</td>
                     <td><textarea placeholder="Inline HTML content" rows="10" cols="120"></textarea></td>
                 </tr>
+                <tr id="references">
+                    <td class="table_label">References</td>
+                    <td>
+                        <textarea style="overflow-y: scroll;" rows="5" cols="80"></textarea>
+                    </td>
+                </tr>
                 <tr id="submit">
                     <td></td>
-                    <td style="text-align: center;"><input value="Add" type="submit" onclick="save_form()"/></td></td>
+                    <td style="text-align: center;"><input value="Add" id="submit_button" type="submit" onclick="save_form('submit_button')"/></td></td>
                 </tr>
             </table>
         </div>

--- a/genweb/data/editor.js
+++ b/genweb/data/editor.js
@@ -12,7 +12,9 @@ const values_to_clear = [
     "folder",
     "height",
     "width",
-    "contents"
+    "contents",
+    "references",
+    "original"
 ];
 const visible_fields = {
     id:["inline","href", "picture"],
@@ -22,10 +24,12 @@ const visible_fields = {
     people:["inline", "href", "picture"],
     mod_date:["inline", "picture", "href"],
     folder:["href"],
+    original:["picture"],
     height:["picture"],
     caption:["picture"],
     width:["picture"],
     contents:["inline"],
+    references:["inline"],
 };
 
 // MARK: Helpers
@@ -171,7 +175,7 @@ function load_metadata_into(metadata_identifier) {
                 var row_input = get_row_input(field);
                 const field_has_row = (row_input.length > 0);
 
-                if ( field_has_row && field == 'people') {
+                if ( field_has_row && (field == 'people' || field == 'references')) {
                     row_input[0].value = metadata_info[field].join("\n");
                 } else if ( field_has_row && field != 'id') {
                         row_input[0].value = metadata_info[field];
@@ -299,6 +303,9 @@ function save_form(button_id) {
             }
 
             clear_form();
+        }
+        
+        if (this.readyState == 4) {
             submit_button.disabled = false;
         }
     }

--- a/genweb/webapi_v1.py
+++ b/genweb/webapi_v1.py
@@ -154,3 +154,4 @@ class ApiV1:
         self.metadata[identifier] = metadata
         self.metadata.save()
         body = dumps(metadata).encode("utf-8")
+        return body, mimetype, response_code


### PR DESCRIPTION
- Web editor now adds fields for original for picture and references for inline
- Fixed an error where the metadata type was being removed after updating
- Reenable Submit button when update is complete
- If API errors occur, an errors section will appear at the bottom of the page with a log of all the errors
- Fixed POSTing updates to actually return the metadata on success
Closes #70 