### PR TITLE
Fixing duplicate thumbnail warning

### DIFF
--- a/genweb/genweb.py
+++ b/genweb/genweb.py
@@ -114,18 +114,14 @@ def copy_person_thumbnails(
             continue
 
         dest_file = destination_file(join(dst_dir, person.id), f"{person.id}.jpg")
-        found = artifacts.paths(f"{person.id}.jpg")
+        source_file = join(person.id, f"{person.id}.jpg")
 
-        if not found:
+        if not artifacts.has_file(source_file):
             link(join(dst_dir, default_thumbnail), dest_file)
             continue
 
-        if len(found) != 1:
-            PRINT(f"WARNING: duplicate thumbnails for {person.id}")
-            PRINT("\t" + "\n\t".join(found))
-
-        link(join(artifacts.directory, found[0]), dest_file)
-        artifacts.add(found[0])
+        link(join(artifacts.directory, source_file), dest_file)
+        artifacts.add(source_file)
 
 
 def copy_metadata_files(

--- a/tests/test_genweb.py
+++ b/tests/test_genweb.py
@@ -85,6 +85,11 @@ def test_copy_metadata_files() -> None:
     with TemporaryDirectory() as src_dir, TemporaryDirectory() as dst_dir:
         copytree(join(dirname(__file__), "data"), join(src_dir, "data"))
         makedirs(join(dst_dir, "foo"))
+        makedirs(join(src_dir, "1"))
+        copy(
+            join(dirname(__file__), "data", "fake.jpg"),
+            join(src_dir, "1", "1.jpg"),
+        )
         copy(
             join(dirname(__file__), "data", "test.xml"),
             join(dst_dir, "foo", "test.xml"),
@@ -109,17 +114,15 @@ def test_copy_metadata_files() -> None:
         copy_metadata_files(artifacts, dst_dir, metadata, people, default_thumbnail)
         assert isfile(join(dst_dir, "foo", "test.xml"))
 
-        with open(join(dst_dir, "1", "1.jpg"), "r", encoding="utf-8") as file_1:
+        with open(join(dst_dir, "fake", "fake.jpg"), "r", encoding="utf-8") as file_1:
             fake2_contents = file_1.read()
 
-        assert fake2_contents.startswith("default")
+        assert fake2_contents.startswith("default"), fake2_contents
 
-        with open(
-            join(dst_dir, "fake", "fake.jpg"), "r", encoding="utf-8"
-        ) as file_fake:
+        with open(join(dst_dir, "1", "1.jpg"), "r", encoding="utf-8") as file_fake:
             fake_contents = file_fake.read()
 
-        assert fake_contents.startswith("not really an image")
+        assert fake_contents.startswith("not really an image"), fake_contents
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I changed the assumption on how to get the thumbnails. We now always get them from the `<person_id>/<person_id>.jpg` path.