### PR TITLE
Update devopsdriver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "PyYAML==6.0.2",
   "Mako==1.3.5",
   "python-gedcom==1.0.0",
-  "devopsdriver==0.1.46",
+  "devopsdriver==0.1.48",
   "boto3==1.35.10",
 ]
 keywords = ["geneology", "familyhistory", "photos"]


### PR DESCRIPTION
Prepping for getting rid of files and directories referencing `devopsdriver`

The latest version allows you to override the `devopsdriver` name with another default name. 

We could make the Linux settings directory `~/.genweb` instead of `~/.devopsdriver`